### PR TITLE
Fix `formula.variables()` for expressions with complex numbers

### DIFF
--- a/src/cseval/cseval.cpp
+++ b/src/cseval/cseval.cpp
@@ -65,8 +65,7 @@ cseval<Real>::cseval(const cseval<Real> &other)
       id_(std::string(other.id_)),
       value_(Real(other.value_)),
       left_eval_(nullptr),
-      right_eval_(nullptr),
-      imaginary_unit_(other.imaginary_unit_) {
+      right_eval_(nullptr) {
 #ifdef CSDEBUG
   std::cout << "copy constructor cseval+, kind: " << kind_ << ", id: " << id_
             << std::endl;
@@ -83,13 +82,12 @@ cseval<Real>::cseval(const cseval<Real> &other)
 }
 
 template <typename Real>
-cseval<Real>::cseval(std::string expression, char imaginary_unit)
+cseval<Real>::cseval(std::string expression)
     : kind_('e'),
       id_(""),
       value_("0"),
       left_eval_(nullptr),
-      right_eval_(nullptr),
-      imaginary_unit_(imaginary_unit) {
+      right_eval_(nullptr) {
 #ifdef CSDEBUG
   std::cout << "constructor cseval, expression:" << expression << std::endl;
 #endif
@@ -154,12 +152,6 @@ location and / or number of brackets");
       kind_ = 'n';
       id_ = "pi";
       value_ = Real(M_PI_STR);
-    } else if (expression == std::string(1, imaginary_unit_)) {
-      throw std::invalid_argument(
-          (boost::format("Complex number indicator was founded in \
-the expression: %s. Not implemented at the class for Real numbers") %
-           expression)
-              .str());
     } else if (std::regex_match(expression, kIsNumberRegex)) {
       kind_ = 'n';
       id_ = expression;

--- a/src/cseval/cseval.hpp
+++ b/src/cseval/cseval.hpp
@@ -49,13 +49,6 @@ class cseval {
   /** Child elements of the formula tree. */
   cseval *left_eval_, *right_eval_;
 
-  /**
-   * Symbol of the imaginary unit (by default - 'i').
-   * Only one Latin character (!).
-   * TODO: delete me.
-   */
-  const char imaginary_unit_;
-
   /** Try to find each symbol of {symbols} string in the {str} string. */
   std::unordered_map<char, size_t> operations_outside_parentheses(
       const std::string &str, const std::string &symbols) const;
@@ -64,7 +57,7 @@ class cseval {
   bool isThereSymbolsOutsideParentheses(const std::string &str) const;
 
  public:
-  cseval(std::string expression, char imaginary_unit = 'i');
+  cseval(std::string expression);
 
   cseval(const cseval &other);
 
@@ -75,7 +68,6 @@ class cseval {
       kind_ = other.kind_;
       id_ = std::string(other.id_);
       value_ = Real(other.value_);
-      imaginary_unit_ = other.imaginary_unit_;
       if (left_eval_) {
         delete left_eval_;
       }

--- a/src/cseval/cseval_complex.hpp
+++ b/src/cseval/cseval_complex.hpp
@@ -22,13 +22,9 @@ using mp_complex =
     boost::multiprecision::number<boost::multiprecision::cpp_complex_backend<N>,
                                   boost::multiprecision::et_off>;
 
-// TODO Complex numbers
-// typedef std::complex<float100et> complexFloat100et;
-
 /**
  * Class for evaluating formula specified by the string
- * TODO: which double?
- * typename Complex (not mp_complex<NUMBER>) for double support.
+ * typename Complex (de facto mp_complex<NUMBER>).
  */
 template <typename Complex>
 class cseval_complex {

--- a/src/csformula/csformula.cpp
+++ b/src/csformula/csformula.cpp
@@ -176,6 +176,17 @@ location and / or number of brackets");
   boost::algorithm::erase_all(expression_, "\t");
   boost::algorithm::erase_all(expression_, "\v");
 
+  if (case_insensitive_) {
+    // TODO cannot give back to user the original expression?
+    boost::algorithm::to_lower(expression_);
+    if (imaginary_unit_ != tolower(imaginary_unit_)) {
+      throw std::invalid_argument(
+          "Uppercase imaginary unit for case insensitive expressions \
+is not supported. Specify imaginary unit in lower \
+case for case insensitive expressions.");
+    }
+  }
+
   // Check whether expression_ contains complex numbers or not.
   if (case_insensitive_) {
     std::regex regexp_check_complex_numbers(
@@ -188,10 +199,10 @@ location and / or number of brackets");
     is_complex_ = std::regex_search(expression_, regexp_check_complex_numbers);
   }
 
-  if (case_insensitive_) {
-    // TODO cannot give back to user the original expression?
-    boost::algorithm::to_lower(expression_);
-    // TODO cannot give back to user the original expression?
-    // boost::algorithm::to_lower(imaginary_unit_);
+  if (is_complex_ && expression_.find("<") != std::string::npos or
+      expression_.find(">") != std::string::npos) {
+    throw std::invalid_argument(
+        "The given formula expression with complex numbers contains wrong \
+symbols: '<' or '>'");
   }
 }

--- a/src/csformula/csformula.hpp
+++ b/src/csformula/csformula.hpp
@@ -167,7 +167,11 @@ class Formula {
     std::unordered_set<std::string> variables;
     auto visitor =
         std::bind(CollectVariablesVisitor(), &variables, std::placeholders::_1);
-    boost::apply_visitor(visitor, eval_);
+    if (is_complex_) {
+        boost::apply_visitor(visitor, eval_complex_);
+    } else {
+        boost::apply_visitor(visitor, eval_);
+    }
     return variables;
   }
 

--- a/src/csformula/csformula.hpp
+++ b/src/csformula/csformula.hpp
@@ -117,9 +117,8 @@ class Formula {
             std::make_shared<cseval_complex<mp_complex<precisions_array[I]>>>(
                 expression_, imaginary_unit_);
       } else {
-        // TODO: delete imaginary_unit_
-        eval_ = std::make_shared<cseval<mp_real<precisions_array[I]>>>(
-            expression_, imaginary_unit_);
+        eval_ =
+            std::make_shared<cseval<mp_real<precisions_array[I]>>>(expression_);
       }
     } else if (I + 1 < kPrecisionsLength) {
       init_eval<I + 1>();
@@ -168,9 +167,9 @@ class Formula {
     auto visitor =
         std::bind(CollectVariablesVisitor(), &variables, std::placeholders::_1);
     if (is_complex_) {
-        boost::apply_visitor(visitor, eval_complex_);
+      boost::apply_visitor(visitor, eval_complex_);
     } else {
-        boost::apply_visitor(visitor, eval_);
+      boost::apply_visitor(visitor, eval_);
     }
     return variables;
   }

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -189,10 +189,29 @@ def test_complex_numbers_1():
         == "-3.14159265358979323846264+i*(0.00000000000000000000000)"
     )
 
+    formula = Formula("2*asin(x)*i*i", 24)
+    assert (
+        formula.get({"x": "1"}, digits=23, format=FmtFlags.scientific)
+        == "-3.14159265358979323846264e+00+i*(0.00000000000000000000000e+00)"
+    )
+
     formula = Formula("2*asin(x)*i*i*i^2", 24)
     assert (
         formula.get({"x": "1"}, digits=23, format=FmtFlags.fixed)
         == "3.14159265358979323846264+i*(0.00000000000000000000000)"
+    )
+
+
+def test_complex_numbers_variables():
+    """Complex numbers."""
+    formula = Solver("2*asin(x)*i*i", 24)
+    assert (
+        formula.variables() == {"x"}
+    )
+
+    formula = Solver("2*asin(x*y*z)*i*i/qwerty/asdfg", 24)
+    assert (
+        formula.variables() == {"x", "y", "z", "qwerty", "asdfg"}
     )
 
 


### PR DESCRIPTION
```
>>> formula = Solver("2*asin(x)*i*i", 24)
>>> formula.get({"x": "1"}, digits=23, format=FmtFlags.fixed)
'-3.14159265358979323846264+i*(0.00000000000000000000000)'
>>> formula.get({"x": "1"}, digits=23, format=FmtFlags.default)
'-3.1415926535897932384626+i*(0)'
>>> formula.get({"x": "1"}, digits=23, format=FmtFlags.scientific)
'-3.14159265358979323846264e+00+i*(0.00000000000000000000000e+00)'
>>> formula.get({"x": "1"}, digits=23)
'-3.1415926535897932384626+i*(0)'
>>> formula.get({"x": "1"})
'-3.1415926535897932384626438+i*(0)'
>>> formula.get(1)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: get(): incompatible function arguments. The following argument types are supported:
    1. (self: formula._formula.Formula, variables_to_values: Dict[str, str] = {}, digits: int = 0, format: formula._formula.FmtFlags = <formula._formula.FmtFlags object at 0x7f47e8802870>) -> str

Invoked with: <formula.formula.Solver object at 0x7f47e87bae10>, 1
>>> formula.get({"x": 1})
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: get(): incompatible function arguments. The following argument types are supported:
    1. (self: formula._formula.Formula, variables_to_values: Dict[str, str] = {}, digits: int = 0, format: formula._formula.FmtFlags = <formula._formula.FmtFlags object at 0x7f47e8802870>) -> str

Invoked with: <formula.formula.Solver object at 0x7f47e87bae10>, {'x': 1}
>>> formula.get({"x": "1"})
'-3.1415926535897932384626438+i*(0)'
>>> formula.variables()
Segmentation fault (core dumped)
```