### PR TITLE
Fix CI/CD matrix + wheel builds (reduce macOS load, add PyPy 3.11 support)

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -88,7 +88,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        os: [ubuntu-latest, macos-14, windows-latest]
     steps:
       - uses: actions/checkout@v4
       - name: Restore bumped __init__.py
@@ -98,7 +98,10 @@ jobs:
           name: bumped-source
           path: src/formula/
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.21.3
+        # v2.23.x is the last 2.x series before cibuildwheel 3.0 (which
+        # requires Python >= 3.11 to *run* and changes PyPy enablement).
+        # 2.23 has stable PyPy 3.11 support.
+        uses: pypa/cibuildwheel@v2.23.3
       - name: Upload wheel artifacts
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/test-mac.yml
+++ b/.github/workflows/test-mac.yml
@@ -22,14 +22,14 @@ jobs:
       matrix:
         # macos-13 = x86_64, macos-14 = arm64 (Apple Silicon).
         os: [macos-14]
-        python: ["3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python: ["3.9", "3.12", "pypy-3.9", "pypy-3.11"]
         exclude:
-          # PyPy does not ship arm64 macOS builds (as of late 2025); skip
+          # PyPy does not ship arm64 macOS builds (as of mid-2026); skip
           # rather than let setup-python fail to find a distribution.
           - os: macos-14
             python: pypy-3.9
           - os: macos-14
-            python: pypy-3.10
+            python: pypy-3.11
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test-ubu.yml
+++ b/.github/workflows/test-ubu.yml
@@ -17,9 +17,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-22.04, ubuntu-latest]
+        os: [ubuntu-latest]
         architecture: [x64]
-        python: ["3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python: ["3.9", "3.12", "pypy-3.9", "pypy-3.11"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python }}

--- a/.github/workflows/test-win.yml
+++ b/.github/workflows/test-win.yml
@@ -17,13 +17,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2022, windows-latest]
+        os: [windows-latest]
         architecture: [x86, x64]
-        python: ["3.9", "3.10", "3.11", "3.12", "pypy-3.9", "pypy-3.10"]
+        python: ["3.9", "3.12", "pypy-3.9", "pypy-3.11"]
         exclude:
           - python: "pypy-3.9"
             architecture: x86
-          - python: "pypy-3.10"
+          - python: "pypy-3.11"
             architecture: x86
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,8 +3,13 @@ requires = ["setuptools>=61", "wheel", "pybind11>=2.10,<3"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* pp39-* pp310-*"
-skip = "*-musllinux_i686 *-win32 pp*-win_*"
+build = "cp39-* cp310-* cp311-* cp312-* pp39-* pp310-* pp311-*"
+# Skip patterns:
+# - *-musllinux_i686: 32-bit Alpine; vanishingly small audience.
+# - pp*-win*: PyPy on Windows is not shipped upstream. The trailing `*` (no
+#   underscore) catches both `pp*-win_amd64` and `pp*-win32`.
+# CPython Windows x86 (cp*-win32) is built.
+skip = "*-musllinux_i686 pp*-win*"
 build-verbosity = 1
 test-requires = ["pytest"]
 test-command = "python -m pytest --verbose {project}/tests"
@@ -19,3 +24,20 @@ archs = ["x86_64"]
 
 [tool.cibuildwheel.windows]
 archs = ["AMD64", "x86"]
+
+# PyPy's sysconfig does not populate LDSHARED / LDCXXSHARED. Setuptools
+# >= 70 reads `linker_so_cxx` from LDCXXSHARED for C++ extensions; without
+# it, the link step crashes with `'NoneType' object is not subscriptable`.
+# The test workflows handle this via $GITHUB_ENV, but cibuildwheel runs in
+# its own isolated venv — so we set the env vars per-PyPy override here.
+# `inherit.environment = "append"` keeps MACOSX_DEPLOYMENT_TARGET from the
+# parent [tool.cibuildwheel.macos] block.
+[[tool.cibuildwheel.overrides]]
+select = "pp*-macosx_*"
+inherit.environment = "append"
+environment = { LDSHARED = "clang++ -bundle -undefined dynamic_lookup", LDCXXSHARED = "clang++ -bundle -undefined dynamic_lookup" }
+
+[[tool.cibuildwheel.overrides]]
+select = "pp*-manylinux_*"
+inherit.environment = "append"
+environment = { LDSHARED = "g++ -shared", LDCXXSHARED = "g++ -shared" }


### PR DESCRIPTION
* Reduced PR test matrix across Ubuntu/Windows/macOS to cut CI time and runner usage while keeping lowest+latest coverage (3.9 and 3.12).
* Updated PyPy coverage to use PyPy 3.11 in CI matrices.
* Stabilized release wheel builds:
* Dropped macos-13 from the wheel build matrix (keeps macos-14).
* Upgraded cibuildwheel to v2.23.3 (staying on 2.x for compatibility).
* Added cibuildwheel overrides to set LDSHARED/LDCXXSHARED for PyPy on macOS/Linux to avoid setuptools 70+ linker crash.
* Adjusted cibuildwheel build/skip patterns (include PyPy 3.11; skip musllinux i686 and PyPy on Windows).