### PR TITLE
fix: stop Solver.__call__ from mutating caller's values dict

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -61,7 +61,12 @@ class Solver(Formula):
         if format_digits is None:
             format_digits = self.precision
 
-        variables_to_values: Dict[str, str] = dict() if values is None else values
+        if values is None:
+            variables_to_values: Dict[str, str] = {}
+        elif isinstance(values, Mapping):
+            variables_to_values = dict(values)
+        else:
+            variables_to_values = values
         if not isinstance(values, Mapping):
             variables = self.variables()
             if not variables:

--- a/tests/test_solver_no_mutate.py
+++ b/tests/test_solver_no_mutate.py
@@ -1,6 +1,4 @@
 """Regression: Solver.__call__ must not mutate the caller's values dict.
-
-See ai/improvements_2026-05-09.md item #1.
 """
 
 from formula import Solver

--- a/tests/test_solver_no_mutate.py
+++ b/tests/test_solver_no_mutate.py
@@ -1,0 +1,31 @@
+"""Regression: Solver.__call__ must not mutate the caller's values dict.
+
+See ai/improvements_2026-05-09.md item #1.
+"""
+
+from formula import Solver
+
+
+def test_solver_does_not_mutate_caller_dict_int_values():
+    solver = Solver("x + 1")
+    values = {"x": 1}
+    snapshot = dict(values)
+    solver(values)
+    assert values == snapshot
+
+
+def test_solver_does_not_mutate_caller_dict_float_values():
+    solver = Solver("a + b")
+    values = {"a": 1.5, "b": 2.5}
+    snapshot = dict(values)
+    solver(values)
+    assert values == snapshot
+
+
+def test_solver_does_not_mutate_caller_dict_string_values_passthrough():
+    solver = Solver("a + b")
+    values = {"a": "1", "b": "2"}
+    snapshot = dict(values)
+    result = solver(values)
+    assert values == snapshot
+    assert result == "3"


### PR DESCRIPTION
Closes item #1 from `ai/improvements_2026-05-09.md`.

**Problem.** `Solver.__call__` aliased the caller's `values` dict (no copy), then mutated it in place when stringifying non-string values. A call like `solver({'x': 1})` silently turned the caller's dict into `{'x': '1'}` — surprising state corruption for any caller who reused the dict.

**Fix.** `src/formula/formula.py` — explicit branch on `values`: `None` → fresh empty dict; `Mapping` → `dict(values)` shallow copy; scalar → leave for the existing 1-variable shorthand path. The downstream stringification loop now mutates our private copy.

**Test.** New file `tests/test_solver_no_mutate.py` with three cases (int, float, already-string values). All pass; full suite 319/319.