### PR TITLE
fix: Number ordering honors precision/imaginary_unit/case_insensitive

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -142,7 +142,7 @@ class Number:
         return [left, right]
 
     def __make_comparison(self, left: str, right: str, operator: str) -> bool:
-        solver = Solver(f"(({left}) {operator} ({right}))")
+        solver = Solver(f"(({left}) {operator} ({right}))", **self.params)
         return solver(format_digits=1) == "1"
 
     def __eq__(self, __value: object) -> bool:

--- a/tests/test_number_comparison_precision.py
+++ b/tests/test_number_comparison_precision.py
@@ -1,11 +1,4 @@
 """Regression: Number ordering must honor the user-supplied precision.
-
-See ai/improvements_2026-05-09.md item #3.
-
-Number.__make_comparison previously built its inner Solver with no params,
-defaulting to precision=24. That truncated high-precision inputs at parse
-time and produced wrong answers for values that differed only beyond the
-24th digit.
 """
 
 from formula import Number

--- a/tests/test_number_comparison_precision.py
+++ b/tests/test_number_comparison_precision.py
@@ -5,21 +5,21 @@ from formula import Number
 
 
 def test_number_gt_at_high_precision():
-    a = Number("1." + "0" * 50 + "1", precision=256)
+    a = Number("1." + "0" * 250 + "1", precision=256)
     b = Number("1.0", precision=256)
     assert a > b
     assert not (b > a)
 
 
 def test_number_lt_at_high_precision():
-    a = Number("1." + "0" * 50 + "1", precision=256)
+    a = Number("1." + "0" * 250 + "1", precision=256)
     b = Number("1.0", precision=256)
     assert b < a
     assert not (a < b)
 
 
 def test_number_ge_le_at_high_precision():
-    a = Number("1." + "0" * 50 + "1", precision=256)
+    a = Number("1." + "0" * 250 + "1", precision=256)
     b = Number("1.0", precision=256)
     assert a >= b
     assert b <= a

--- a/tests/test_number_comparison_precision.py
+++ b/tests/test_number_comparison_precision.py
@@ -1,0 +1,34 @@
+"""Regression: Number ordering must honor the user-supplied precision.
+
+See ai/improvements_2026-05-09.md item #3.
+
+Number.__make_comparison previously built its inner Solver with no params,
+defaulting to precision=24. That truncated high-precision inputs at parse
+time and produced wrong answers for values that differed only beyond the
+24th digit.
+"""
+
+from formula import Number
+
+
+def test_number_gt_at_high_precision():
+    a = Number("1." + "0" * 50 + "1", precision=256)
+    b = Number("1.0", precision=256)
+    assert a > b
+    assert not (b > a)
+
+
+def test_number_lt_at_high_precision():
+    a = Number("1." + "0" * 50 + "1", precision=256)
+    b = Number("1.0", precision=256)
+    assert b < a
+    assert not (a < b)
+
+
+def test_number_ge_le_at_high_precision():
+    a = Number("1." + "0" * 50 + "1", precision=256)
+    b = Number("1.0", precision=256)
+    assert a >= b
+    assert b <= a
+    assert not (b >= a)
+    assert not (a <= b)


### PR DESCRIPTION
**Problem.** `Number.__make_comparison` built its inner `Solver` with no params, falling back to `precision=24`. Two `Number(..., precision=256)` values that differed only beyond the 24th digit were compared as if equal because their numeric values truncated at parse time. `imaginary_unit` and `case_insensitive` were also silently dropped.

**Fix.** `src/formula/formula.py:145` — forward `**self.params` to the comparison Solver, matching what `__make_operation` and `__prepare_comparison` already do.

**Test.** New file `tests/test_number_comparison_precision.py` exercises `<`, `>`, `<=`, `>=` at `precision=256` against a Number that differs at the 52nd digit. All pass; full suite 319/319.