### PR TITLE
fix: Number rich comparisons return NotImplemented for foreign types

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -146,6 +146,8 @@ class Number:
         return solver(format_digits=1) == "1"
 
     def __eq__(self, __value: object) -> bool:
+        if not isinstance(__value, (Number, str, int, float)):
+            return NotImplemented
         left, right = self.__prepare_comparison(__value)
         return left == right
 
@@ -172,24 +174,32 @@ class Number:
         return self.__make_operation(__value, "^")
 
     def __ge__(self, __value: Union["Number", str]) -> bool:
+        if not isinstance(__value, (Number, str, int, float)):
+            return NotImplemented
         left, right = self.__prepare_comparison(__value)
         if left == right:
             return True
         return self.__make_comparison(left, right, ">")
 
     def __gt__(self, __value: Union["Number", str]) -> bool:
+        if not isinstance(__value, (Number, str, int, float)):
+            return NotImplemented
         left, right = self.__prepare_comparison(__value)
         if left == right:
             return False
         return self.__make_comparison(left, right, ">")
 
     def __le__(self, __value: Union["Number", str]) -> bool:
+        if not isinstance(__value, (Number, str, int, float)):
+            return NotImplemented
         left, right = self.__prepare_comparison(__value)
         if left == right:
             return True
         return self.__make_comparison(left, right, "<")
 
     def __lt__(self, __value: Union["Number", str]) -> bool:
+        if not isinstance(__value, (Number, str, int, float)):
+            return NotImplemented
         left, right = self.__prepare_comparison(__value)
         if left == right:
             return False

--- a/tests/test_number_eq_notimplemented.py
+++ b/tests/test_number_eq_notimplemented.py
@@ -1,0 +1,55 @@
+"""Regression: Number rich comparisons return NotImplemented for foreign types.
+
+See ai/improvements_2026-05-09.md item #5.
+
+Before the fix, `Number("1") == None` (or against a list, an object, etc.)
+raised ValueError from the inner expression parser, because str(other) was
+fed into a Solver. Python's data model expects unknown types to be handled
+by returning NotImplemented.
+"""
+
+import pytest
+
+from formula import Number
+
+
+def test_eq_against_none_is_false():
+    assert (Number("1") == None) is False  # noqa: E711 - we want the actual `==`
+
+
+def test_ne_against_none_is_true():
+    assert (Number("1") != None) is True  # noqa: E711
+
+
+def test_eq_against_list_is_false():
+    assert (Number("1") == [1, 2, 3]) is False
+
+
+def test_eq_against_object_is_false():
+    assert (Number("1") == object()) is False
+
+
+def test_eq_with_number_still_works():
+    assert Number("1") == Number("1")
+    assert not (Number("1") == Number("2"))
+
+
+def test_eq_with_str_int_float_still_works():
+    assert Number("1") == "1"
+    assert Number("1") == 1
+    assert Number("1.5") == 1.5
+
+
+def test_lt_against_none_raises_typeerror():
+    with pytest.raises(TypeError):
+        _ = Number("1") < None
+
+
+def test_gt_against_list_raises_typeerror():
+    with pytest.raises(TypeError):
+        _ = Number("1") > [1]
+
+
+def test_le_against_object_raises_typeerror():
+    with pytest.raises(TypeError):
+        _ = Number("1") <= object()

--- a/tests/test_number_eq_notimplemented.py
+++ b/tests/test_number_eq_notimplemented.py
@@ -1,7 +1,5 @@
 """Regression: Number rich comparisons return NotImplemented for foreign types.
 
-See ai/improvements_2026-05-09.md item #5.
-
 Before the fix, `Number("1") == None` (or against a list, an object, etc.)
 raised ValueError from the inner expression parser, because str(other) was
 fed into a Solver. Python's data model expects unknown types to be handled


### PR DESCRIPTION
**Problem.** `Number("1") == None` (and against lists, objects, etc.) raised `ValueError` from the inner C++ expression parser, because `str(other)` was fed straight into a `Solver`. Python's data model expects unknown operand types to return `NotImplemented` so the other side has a chance, then falls back to identity for `==` or `TypeError` for ordering.

**Fix.** `src/formula/formula.py` — guard `__eq__`, `__lt__`, `__gt__`, `__le__`, `__ge__` with `isinstance(__value, (Number, str, int, float))`. Foreign-type `==` now falls back to `False`; foreign-type ordering raises `TypeError` as Python expects.

**Test.** New file `tests/test_number_eq_notimplemented.py` covers `None`, list, and `object()` on the right side, plus the preserved equal/unequal cases for `Number`/`str`/`int`/`float`. All pass; full suite 325/325.