### PR TITLE
fix: make Number hashable so it works in sets and dict keys

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -149,6 +149,14 @@ class Number:
         left, right = self.__prepare_comparison(__value)
         return left == right
 
+    def __hash__(self) -> int:
+        # Canonical hash key: the value formatted in fixed-point at the
+        # configured precision. Two Numbers that compare equal via __eq__
+        # share that formatted form, so this satisfies the Python contract
+        # that a == b implies hash(a) == hash(b).
+        canonical = Solver(self.expression, **self.params)(format_flags=FmtFlags.fixed)
+        return hash(canonical)
+
     def __str__(self) -> str:
         return self.expression
 

--- a/tests/test_number_hashable.py
+++ b/tests/test_number_hashable.py
@@ -1,7 +1,5 @@
 """Regression: Number must be hashable so it works in sets / as dict keys.
 
-See ai/improvements_2026-05-09.md item #6.
-
 Defining __eq__ without __hash__ silently sets __hash__ = None, making
 the class unhashable. The hash is built on the canonical fixed-point
 string so it agrees with __eq__.

--- a/tests/test_number_hashable.py
+++ b/tests/test_number_hashable.py
@@ -1,0 +1,32 @@
+"""Regression: Number must be hashable so it works in sets / as dict keys.
+
+See ai/improvements_2026-05-09.md item #6.
+
+Defining __eq__ without __hash__ silently sets __hash__ = None, making
+the class unhashable. The hash is built on the canonical fixed-point
+string so it agrees with __eq__.
+"""
+
+from formula import Number
+
+
+def test_number_is_hashable():
+    assert isinstance(hash(Number("1")), int)
+
+
+def test_number_in_set_deduplicates_equal_values():
+    s = {Number("1"), Number("2"), Number("1")}
+    assert len(s) == 2
+
+
+def test_number_as_dict_key():
+    d = {Number("1"): "one", Number("2"): "two"}
+    assert d[Number("1")] == "one"
+    assert d[Number("2")] == "two"
+
+
+def test_hash_consistent_with_eq_for_equivalent_forms():
+    a = Number("1.0")
+    b = Number("1")
+    assert a == b
+    assert hash(a) == hash(b)


### PR DESCRIPTION
**Problem.** Python silently sets `__hash__ = None` on any class that overrides `__eq__` without defining `__hash__`. `Number` had `__eq__` but no `__hash__`, so `{Number("1"), Number("2")}` raised `TypeError: unhashable type: 'Number'` — and `Number` couldn't be a dict key or an `lru_cache` argument either.

**Fix.** `src/formula/formula.py` — add `__hash__` that hashes the canonical fixed-point string at the configured precision. Two `Number` instances that compare equal via `__eq__` share that canonical form, satisfying Python's `a == b ⇒ hash(a) == hash(b)` contract.

**Test.** New file `tests/test_number_hashable.py` covers set deduplication, dict-key lookup, and the hash/eq agreement for equivalent forms like `Number("1")` and `Number("1.0")`. All pass; full suite 320/320.