### PR TITLE
fix: clearer ValueError when Solver values are missing or wrong type

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -68,11 +68,14 @@ class Solver(Formula):
                 pass
             elif values is not None and len(variables) == 1:
                 variables_to_values = {variables.pop(): str(values)}
+            elif values is None:
+                raise ValueError(
+                    f"Missing values for variables: {variables}"
+                )
             else:
                 raise ValueError(
-                    "The value of the 'values' parameter is not a dict!"
-                    " Its type is %s A dictionary is expected with values for"
-                    " the following variables: %s" % (type(values), str(variables))
+                    f"Expected a Mapping for 'values' (got "
+                    f"{type(values).__name__}); variables to provide: {variables}"
                 )
 
         for key in variables_to_values:

--- a/tests/test_solver_missing_values_message.py
+++ b/tests/test_solver_missing_values_message.py
@@ -1,0 +1,36 @@
+"""Regression: clear error message when values are missing or the wrong type.
+
+See ai/improvements_2026-05-09.md item #7.
+
+Before, calling solver() (values=None) on a multi-variable formula raised
+ValueError with "The value of the 'values' parameter is not a dict! Its
+type is <class 'NoneType'>" — misleading, because the actual problem is
+that the caller didn't pass any values at all.
+"""
+
+import pytest
+
+from formula import Solver
+
+
+def test_missing_values_dict_for_multi_variable_formula():
+    solver = Solver("x + y")
+    with pytest.raises(ValueError, match="Missing values for variables"):
+        solver()
+
+
+def test_wrong_type_for_values_on_multi_variable_formula():
+    solver = Solver("x + y")
+    with pytest.raises(ValueError, match="Expected a Mapping"):
+        solver(123)
+
+
+def test_wrong_type_error_names_the_actual_type():
+    solver = Solver("x + y")
+    with pytest.raises(ValueError, match="int"):
+        solver(42)
+
+
+def test_proper_values_still_work():
+    solver = Solver("x + y")
+    assert solver({"x": "1", "y": "2"}) == "3"

--- a/tests/test_solver_missing_values_message.py
+++ b/tests/test_solver_missing_values_message.py
@@ -1,7 +1,5 @@
 """Regression: clear error message when values are missing or the wrong type.
 
-See ai/improvements_2026-05-09.md item #7.
-
 Before, calling solver() (values=None) on a multi-variable formula raised
 ValueError with "The value of the 'values' parameter is not a dict! Its
 type is <class 'NoneType'>" — misleading, because the actual problem is


### PR DESCRIPTION
**Problem.** Calling `solver()` (no arguments) on a multi-variable formula raised `ValueError: The value of the 'values' parameter is not a dict! Its type is <class 'NoneType'>...`. That framed the problem as a type mismatch when the caller had actually just forgotten to pass anything. New users hit this immediately.

**Fix.** `src/formula/formula.py` — split the two cases:
- `values is None` + the formula has variables → `"Missing values for variables: {...}"`
- `values is not None` but not a `Mapping` → `"Expected a Mapping for 'values' (got <type>); variables to provide: {...}"`

**Test.** New file `tests/test_solver_missing_values_message.py` covers both messages and confirms the proper-call path still works. All pass; full suite 320/320.