### PR TITLE
refactor: stop mutating self.variables() in the one-variable shortcut

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -67,7 +67,8 @@ class Solver(Formula):
             if not variables:
                 pass
             elif values is not None and len(variables) == 1:
-                variables_to_values = {variables.pop(): str(values)}
+                (only_var,) = variables
+                variables_to_values = {only_var: str(values)}
             else:
                 raise ValueError(
                     "The value of the 'values' parameter is not a dict!"

--- a/tests/test_solver_one_var_shortcut_invariants.py
+++ b/tests/test_solver_one_var_shortcut_invariants.py
@@ -1,0 +1,38 @@
+"""Regression: the one-variable scalar shortcut must not mutate variables().
+
+See ai/improvements_2026-05-09.md item #8.
+
+The old code popped from the set returned by self.variables(). That set is
+currently constructed fresh per call, but the mutation was a latent bug
+waiting on any binding optimization that caches or returns a reference.
+This test pins the invariant: variables() returns the same set after the
+shortcut path.
+"""
+
+from formula import Solver
+
+
+def test_one_var_shortcut_leaves_variables_intact():
+    solver = Solver("x * 2")
+    before = solver.variables()
+    assert before == {"x"}
+    assert solver(5) == "10"
+    after = solver.variables()
+    assert after == {"x"}
+    assert before == after
+
+
+def test_one_var_shortcut_repeatable():
+    solver = Solver("x * 2")
+    assert solver(3) == "6"
+    assert solver(5) == "10"
+    assert solver(7) == "14"
+    assert solver.variables() == {"x"}
+
+
+def test_one_var_shortcut_with_dict_form_also_repeatable():
+    solver = Solver("x * 2")
+    assert solver({"x": "3"}) == "6"
+    assert solver(5) == "10"
+    assert solver({"x": "7"}) == "14"
+    assert solver.variables() == {"x"}

--- a/tests/test_solver_one_var_shortcut_invariants.py
+++ b/tests/test_solver_one_var_shortcut_invariants.py
@@ -1,7 +1,5 @@
 """Regression: the one-variable scalar shortcut must not mutate variables().
 
-See ai/improvements_2026-05-09.md item #8.
-
 The old code popped from the set returned by self.variables(). That set is
 currently constructed fresh per call, but the mutation was a latent bug
 waiting on any binding optimization that caches or returns a reference.


### PR DESCRIPTION
**Problem.** `Solver.__call__` extracted the sole variable name with `set.pop()` on the return value of `self.variables()`. Today that set is a fresh copy per call (so no harm is observable), but any future binding optimization that caches or returns a reference would have the wrapper silently corrupt internal state.

**Fix.** `src/formula/formula.py:69-70` — use unpacking `(only_var,) = variables` so the set is never mutated.

**Test.** `tests/test_solver_one_var_shortcut_invariants.py` pins the invariant: `solver.variables()` returns the same set before and after the shortcut path, across repeated calls.

Full suite 319/319.