### PR TITLE
refactor: accumulate Number arithmetic symbolically

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -132,8 +132,7 @@ class Number:
 
     def __make_operation(self, __value: object, operator: str) -> "Number":
         val = __value.expression if isinstance(__value, Number) else str(__value)
-        solver = Solver(f"(({self.expression}) {operator} ({val}))", **self.params)
-        return Number(solver(), **self.params)
+        return Number(f"(({self.expression}) {operator} ({val}))", **self.params)
 
     def __prepare_comparison(self, __value: object) -> List[str]:
         left = Solver(self.expression, **self.params)(format_flags=FmtFlags.fixed)
@@ -150,9 +149,14 @@ class Number:
         return left == right
 
     def __str__(self) -> str:
-        return self.expression
+        return Solver(self.expression, **self.params)()
 
     def __abs__(self) -> "Number":
+        # __abs__ stays eager for now: symbolic abs() exposes precision
+        # artifacts in complex-magnitude identities (e.g. sin²+cos² rounding
+        # to 1 + 1 ULP at low precision) that the eager round-trip used to
+        # mask via default-format trailing-zero stripping. Arithmetic ops
+        # are still symbolic; that's where chained-precision loss matters.
         solver = Solver(f"abs({self.expression})", **self.params)
         return Number(solver(), **self.params)
 

--- a/tests/test_number_symbolic.py
+++ b/tests/test_number_symbolic.py
@@ -1,0 +1,41 @@
+"""Regression: Number arithmetic accumulates symbolically; ops do not lose
+precision through formatted-string round-trips.
+
+See ai/improvements_2026-05-09.md items #9 and #10.
+
+Before, every arithmetic op evaluated the expression eagerly and stored the
+formatted result string as the new Number's expression. Each subsequent op
+re-parsed that rounded string. This test pins the new behavior: arithmetic
+builds a symbolic expression that is evaluated only when str() / __eq__ is
+called.
+"""
+
+from formula import Number
+
+
+def test_expression_is_symbolic_after_addition():
+    n = Number("1.1") + "1.1"
+    # The combined symbolic form is kept; we do not see the eager "2.2" eval.
+    assert "1.1" in n.expression
+    assert "+" in n.expression
+
+
+def test_str_still_evaluates_the_symbolic_expression():
+    # The user-facing str() output remains the *value*, not the symbolic form.
+    assert str(Number("1.1") + "1.1") == "2.2"
+    assert str(Number("1.1") - "1.2") == "-0.1"
+    assert str(Number("3") * "4") == "12"
+
+
+def test_chained_arithmetic_evaluates_correctly():
+    # Each step builds on the previous symbolic expression; final eval reads
+    # the whole tree at the configured precision.
+    result = (Number("1.1") * Number("2") + Number("0.8")) ** 2
+    assert result == "9"
+
+
+def test_abs_result_evaluates_correctly():
+    # __abs__ stays eager (see comment in formula.py); the user-facing
+    # str() output is still the canonical complex magnitude.
+    n = abs(Number("4-3*i"))
+    assert str(n) == "5+i*(0)"


### PR DESCRIPTION
Closes items #9 and #10 from `ai/improvements_2026-05-09.md` (combined per the doc's recommendation: "Combine with #9").

**Problem.** The five arithmetic ops (`+`, `-`, `*`, `/`, `^`) used to evaluate eagerly and stash the formatted result string as the new `Number`'s `expression`. Each subsequent op re-parsed that rounded string, so chained operations on a high-precision `Number` could not exceed the precision of formatted output — and string-interpolation of formatted complex outputs back into new expressions was fragile.

**Fix.** `src/formula/formula.py` — `__make_operation` now builds a symbolic expression `((self.expression) <op> (val))` and returns a Number that carries the full tree. `__str__` evaluates that tree once at the configured precision. User-facing output is unchanged.

**Scope of this PR.** Symbolic accumulation applies to arithmetic only. `__abs__` is **left eager** with a code comment explaining why: the symbolic form would expose precision artifacts in complex-magnitude identities (e.g. `abs(-sin(pi/8)-i*cos(pi/8))` evaluates to `1.000…001 + i*(0)` at precision 24, not exact 1) that the eager round-trip used to mask via default-format trailing-zero stripping. Arithmetic ops are where chained-precision loss matters; abs is a one-shot call.

**API note.** This changes `Number.expression`'s meaning after arithmetic — it now carries the symbolic combination, not the eager-evaluated string. Existing callers that read `.expression` after arithmetic will see something like `"((1.1) + (1.1))"` instead of `"2.2"`. The user-facing `str()` output is unchanged.

**Test.** New file `tests/test_number_symbolic.py` covers: expression is symbolic after `+`, str() still evaluates, deep chains produce correct results, and the eager-abs result still evaluates correctly. Full suite 320/320.