### PR TITLE
fix: add zip-slip guard to update_command.py

### DIFF
--- a/boost_headers/update_command.py
+++ b/boost_headers/update_command.py
@@ -37,6 +37,17 @@ with urllib.request.urlopen(url) as response, open(
 print("Unzip...")
 
 with zipfile.ZipFile(script_dir / file_name_ext, "r") as zip_ref:
+    # Zip-slip guard: refuse archives whose entries would write outside
+    # script_dir. Boost releases are trusted, but the URL is unauthenticated
+    # so a mirror compromise (or a typo in --version pointing at the wrong
+    # asset) shouldn't be able to overwrite arbitrary files on the host.
+    target_root = script_dir.resolve()
+    for member in zip_ref.namelist():
+        dest = (target_root / member).resolve()
+        try:
+            dest.relative_to(target_root)
+        except ValueError:
+            raise RuntimeError(f"Unsafe path in archive: {member!r}")
     zip_ref.extractall(script_dir)
 
 print("Delete all except the 'boost' catalog with headers...")


### PR DESCRIPTION
**Problem.** `ZipFile.extractall()` will write outside the target directory if the archive contains entries with `..` or absolute paths. Boost releases are trusted, but the URL is unauthenticated and `--version` is user-supplied — a mirror compromise or a typo pointing at the wrong asset shouldn't be able to overwrite arbitrary files on the host.

**Fix.** `boost_headers/update_command.py` — before `extractall`, resolve each `namelist()` entry against `script_dir.resolve()` and call `Path.relative_to()`. Anything that escapes raises `RuntimeError` before any write happens.

**No unit test in this PR.** The script lacks an `if __name__ == "__main__":` guard (item #22, in the cleanup batch PR), so it cannot be imported without running the argparse + download + rmtree flow. The check is small and reviewable inline; once #22 lands, a follow-up can extract the guard into a testable helper. Full suite still 316/316.