### PR TITLE
fix: point update_command.py at the current Boost mirror

### DIFF
--- a/boost_headers/update_command.py
+++ b/boost_headers/update_command.py
@@ -26,7 +26,7 @@ print("Output:", file_name_ext)
 
 print("Download...")
 
-url = f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{file_name_ext}"
+url = f"https://archives.boost.io/release/{version}/source/{file_name_ext}"
 chunk_size = 65536
 with urllib.request.urlopen(url) as response, open(
     script_dir / file_name_ext, "wb"


### PR DESCRIPTION
**Problem.** `boostorg.jfrog.io` was decommissioned. Anyone running `boost_headers/update_command.py` against a recent Boost version gets a 404 (or a stale cached asset). The script is the only way to refresh the vendored headers.

**Fix.** `boost_headers/update_command.py:29` — switch to `https://archives.boost.io/release/{version}/source/{file_name_ext}`, the current canonical Boost release mirror.

Path format verified against the archives.boost.io directory listing (e.g. `release/1.83.0/source/boost_1_83_0.zip`).

No test added — running the script genuinely downloads ~150MB. Static syntax check passes.