### PR TITLE
refactor: make dev/release Boost-headers switch explicit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,11 +28,24 @@ def _read_version():
 __version__ = _read_version()
 
 
+# Header-tree selection.
+#
+# - "boost_headers/" is the vendored, pruned tree that ships in every sdist
+#   and is the default for release builds.
+# - "boost/" is the freshly downloaded tree produced by
+#   boost_headers/update_command.py, used while bumping Boost versions
+#   locally.
+#
+# Opt into the dev tree explicitly by setting FORMULA_USE_DEV_BOOST=1 in the
+# environment. The previous heuristic (any version string starting with
+# "dev") missed PEP 440 pre-release identifiers (e.g. "4.1.0.dev0") and
+# couldn't be exercised without editing __version__ in source.
 DEV_BOOST_HEADERS = os.path.join(CURRENT_DIR, "boost", "boost")
-if __version__.startswith("dev") and os.path.exists(DEV_BOOST_HEADERS):
-    BOOST_HEADERS = "boost/"
-else:
-    BOOST_HEADERS = "boost_headers/"
+USE_DEV_BOOST = bool(os.environ.get("FORMULA_USE_DEV_BOOST")) and os.path.exists(
+    DEV_BOOST_HEADERS
+)
+BOOST_HEADERS = "boost/" if USE_DEV_BOOST else "boost_headers/"
+print(f"setup.py: BOOST_HEADERS={BOOST_HEADERS!r}")
 
 
 EXTRA_COMPILE_ARGS = []


### PR DESCRIPTION
Closes item #14 from `ai/improvements_2026-05-09.md`.

**Problem.** `setup.py` picked between the vendored `boost_headers/` tree and the freshly-downloaded `boost/` tree using `__version__.startswith("dev")`. Two issues:
- PEP 440 pre-release identifiers (`4.1.0.dev0`, `4.1.0a1`) didn't match the `startswith` check, so the switch was effectively dead code for any version following PEP 440.
- The only way to flip the switch was to edit `__version__` in source — entangling header-tree choice with the unrelated version string.

**Fix.** `setup.py:31-35` — drive the choice off `FORMULA_USE_DEV_BOOST` env var: any truthy value (e.g. `=1`) picks `boost/` when the directory exists, anything else falls back to `boost_headers/`. Print the chosen path so it appears in CI logs and `pip install` output.

**Verification.** Rebuilt the extension (`pip install -e .`) and ran the full pytest suite (316/316).