### PR TITLE
fix: don't fail the build when README.md is missing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,8 +62,14 @@ EXT_MODULES = [
 
 TEST_DEPS = ["pytest"]
 
-with open(os.path.join(CURRENT_DIR, "README.md"), encoding="utf-8") as readme_file:
-    LONG_DESCRIPTION = readme_file.read()
+README_PATH = os.path.join(CURRENT_DIR, "README.md")
+if os.path.exists(README_PATH):
+    with open(README_PATH, encoding="utf-8") as readme_file:
+        LONG_DESCRIPTION = readme_file.read()
+else:
+    # Don't fail the build if README.md is missing (partial checkout, tampered
+    # sdist, custom build root). The long_description is metadata-only.
+    LONG_DESCRIPTION = ""
 
 
 setup(


### PR DESCRIPTION
**Problem.** `setup.py` did `open(README.md)` unconditionally at module import. If the file was missing (partial checkout, tampered sdist, custom build root), the failure mode was a cryptic `FileNotFoundError` from inside `setup.py` rather than a clean `setup()`-time error. `long_description` is metadata-only — it shouldn't block the build.

**Fix.** `setup.py:65-66` — wrap the read in `os.path.exists()` and fall back to an empty `LONG_DESCRIPTION` when the file isn't present.

**Verification.** Rebuilt the extension and ran the full pytest suite (316/316).