### PR TITLE
build: add CPython 3.13 and 3.14 to wheel matrix and classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61", "wheel", "pybind11>=2.10,<3"]
 build-backend = "setuptools.build_meta"
 
 [tool.cibuildwheel]
-build = "cp39-* cp310-* cp311-* cp312-* pp39-* pp310-* pp311-*"
+build = "cp39-* cp310-* cp311-* cp312-* cp313-* cp314-* pp39-* pp310-* pp311-*"
 # Skip patterns:
 # - *-musllinux_*: Alpine/musl Linux. Boost's nested cpp_bin_float<N> variant
 #   templates (18 precisions x variant visitors) blow compiler memory even

--- a/setup.py
+++ b/setup.py
@@ -79,6 +79,8 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Scientific/Engineering :: Mathematics",
         "Topic :: Scientific/Engineering :: Physics",
     ],


### PR DESCRIPTION
Closes item #16 from `ai/improvements_2026-05-09.md`.

**Problem.** `pyproject.toml`'s cibuildwheel `build` glob lists `cp39-* cp310-* cp311-* cp312-*` only. CPython 3.13 has been GA since October 2024 and 3.14 since October 2025; users on either fall through to the sdist path, which requires a working C++ toolchain.

**Fix.**
- `pyproject.toml` — append `cp313-* cp314-*` to the build glob.
- `setup.py` — add the matching Trove classifiers for 3.13 and 3.14 so `pip search` / PyPI surfaces report support correctly. `python_requires` is already `>=3.9, <4` and covers both.

**Out of scope:** README badges and the "wheels for 3.9 – 3.12" sentence still claim the old range — a documentation-only follow-up should sync those.