### PR TITLE
build: move static metadata to pyproject.toml [project] table

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,51 @@
 requires = ["setuptools>=61", "wheel", "pybind11>=2.10,<3"]
 build-backend = "setuptools.build_meta"
 
+# Project metadata.
+#
+# version is provided dynamically from src/formula/__init__.py via the
+# imperative setup() call in setup.py — there's a single source of truth
+# for the version string, and setup.py also needs it to populate the
+# VERSION_INFO macro on the C++ extension.
+[project]
+name = "formula"
+dynamic = ["version"]
+description = "Arbitrary-precision formula parser and solver."
+readme = { file = "README.md", content-type = "text/markdown" }
+license = "Apache-2.0"
+license-files = ["LICENSE"]
+authors = [{ name = "Ivan Ergunov", email = "hozblok@gmail.com" }]
+requires-python = ">=3.9, <4"
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Operating System :: OS Independent",
+    "Programming Language :: C++",
+    "Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Scientific/Engineering :: Mathematics",
+    "Topic :: Scientific/Engineering :: Physics",
+]
+
+[project.urls]
+Homepage = "https://github.com/hozblok/formula"
+
+[project.optional-dependencies]
+test = ["pytest"]
+dev = ["pytest"]
+
+[tool.setuptools]
+zip-safe = false
+
+[tool.setuptools.package-dir]
+"" = "src"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
 [tool.cibuildwheel]
 build = "cp39-* cp310-* cp311-* cp312-* pp39-* pp310-* pp311-*"
 # Skip patterns:

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,11 @@
-"""Setup script for the formula C++/Python extension.
+"""Build script for the formula C++/Python extension.
 
-The Python package lives in ``src/formula/`` and the C++ extension sources
-live in ``src/cpp/`` (src-layout). The version string is sourced from
-``src/formula/__init__.py`` so there is a single source of truth.
+Static metadata (name, description, classifiers, dependencies, etc.) lives
+in `pyproject.toml`'s `[project]` table; this file is the imperative
+shim that setuptools still needs to build the pybind11 C++ extension. It
+also supplies the dynamic version (sourced from
+`src/formula/__init__.py`) and the VERSION_INFO macro on the C++ side so
+the version string remains a single source of truth.
 """
 
 import os
@@ -11,7 +14,7 @@ import sys
 
 # Available at setup time due to pyproject.toml
 from pybind11.setup_helpers import Pybind11Extension, build_ext
-from setuptools import find_packages, setup
+from setuptools import setup
 
 CURRENT_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -78,49 +81,8 @@ EXT_MODULES = [
     )
 ]
 
-TEST_DEPS = ["pytest"]
-
-README_PATH = os.path.join(CURRENT_DIR, "README.md")
-if os.path.exists(README_PATH):
-    with open(README_PATH, encoding="utf-8") as readme_file:
-        LONG_DESCRIPTION = readme_file.read()
-else:
-    # Don't fail the build if README.md is missing (partial checkout, tampered
-    # sdist, custom build root). The long_description is metadata-only.
-    LONG_DESCRIPTION = ""
-
-
 setup(
-    author_email="hozblok@gmail.com",
-    author="Ivan Ergunov",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Operating System :: OS Independent",
-        "Programming Language :: C++",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Topic :: Scientific/Engineering :: Mathematics",
-        "Topic :: Scientific/Engineering :: Physics",
-    ],
-    cmdclass={"build_ext": build_ext},
-    description="Arbitrary-precision formula parser and solver.",
-    ext_modules=EXT_MODULES,
-    extras_require={
-        "test": TEST_DEPS,
-        "dev": TEST_DEPS,
-    },
-    license="Apache-2.0",
-    long_description_content_type="text/markdown",
-    long_description=LONG_DESCRIPTION,
-    name="formula",
-    package_dir={"": "src"},
-    packages=find_packages(where="src"),
-    python_requires=">=3.9, <4",
-    url="https://github.com/hozblok/formula",
     version=__version__,
-    zip_safe=False,
+    cmdclass={"build_ext": build_ext},
+    ext_modules=EXT_MODULES,
 )


### PR DESCRIPTION
Closes item #17 from `ai/improvements_2026-05-09.md`.

**Problem.** All package metadata lived in `setup.py`. Modern tooling (uv, hatch, pip-tools, dependency scanners, IDE indexers) reads `pyproject.toml` directly and shouldn't need to invoke `setup.py` to learn the name, version, classifiers, or dependencies. Setuptools >= 61 has supported declarative `[project]` for years; the project's build system already requires `setuptools>=61` in `[build-system]`.

**Fix.**
- `pyproject.toml` — add a complete `[project]` table: `name`, `description`, `readme`, `license` + `license-files`, `authors`, `requires-python`, `classifiers`, `[project.urls]`, `[project.optional-dependencies]`. Version stays dynamic (`dynamic = ["version"]`) so `__version__` in `src/formula/__init__.py` remains the single source of truth. Package discovery moves to `[tool.setuptools.package-dir]` and `[tool.setuptools.packages.find]`.
- `setup.py` — trim to the imperative bits: read `__version__`, compute `BOOST_HEADERS` and `EXTRA_COMPILE_ARGS`, declare the `Pybind11Extension`, and call `setup(version=..., ext_modules=..., cmdclass=...)`. The version pass-through keeps the `VERSION_INFO` macro on the C++ side fed from the same string.

**Verification.** Rebuilt the extension and ran the full pytest suite (316/316). `importlib.metadata.metadata('formula')` on the installed package reports name, version, summary, license, author email, and all 11 classifiers correctly.