### PR TITLE
fix: enforce MAX_PRECISION bound in Solver.__init__

### DIFF
--- a/src/formula/__init__.py
+++ b/src/formula/__init__.py
@@ -4,6 +4,4 @@ __version__ = "4.0.3"
 
 # pylint: disable=no-name-in-module, import-error
 from ._formula import FmtFlags, Formula
-from .formula import Solver, Number
-
-MAX_PRECISION = 8192
+from .formula import MAX_PRECISION, Number, Solver

--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -22,7 +22,12 @@ class Solver(Formula):
         imaginary_unit: str = "i",
         case_insensitive: bool = False,
     ):
-        # pylint: disable=useless-super-delegation
+        from formula import MAX_PRECISION
+
+        if not 0 <= precision <= MAX_PRECISION:
+            raise ValueError(
+                f"precision must be in [0, {MAX_PRECISION}] (got {precision})"
+            )
         super().__init__(expression, precision, imaginary_unit, case_insensitive)
 
     def __call__(

--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -6,6 +6,8 @@ from typing import Any, Dict, Iterable, List, Optional, Union
 # pylint: disable=no-name-in-module, import-error
 from ._formula import FmtFlags, Formula
 
+MAX_PRECISION = 8192
+
 
 class Solver(Formula):
     """Solver for calculating string formulas.
@@ -22,8 +24,6 @@ class Solver(Formula):
         imaginary_unit: str = "i",
         case_insensitive: bool = False,
     ):
-        from formula import MAX_PRECISION
-
         if not 0 <= precision <= MAX_PRECISION:
             raise ValueError(
                 f"precision must be in [0, {MAX_PRECISION}] (got {precision})"

--- a/tests/test_solver_precision_bounds.py
+++ b/tests/test_solver_precision_bounds.py
@@ -1,0 +1,40 @@
+"""Regression: Solver enforces the documented precision bounds.
+
+See ai/improvements_2026-05-09.md item #19.
+
+`MAX_PRECISION = 8192` is exported from the package but used to be
+purely decorative — the wrapper forwarded any precision value straight
+to the C++ extension. Now Solver.__init__ rejects values outside
+[0, MAX_PRECISION] with a clear ValueError.
+"""
+
+import pytest
+
+from formula import MAX_PRECISION, Solver
+
+
+def test_solver_accepts_max_precision():
+    # Boundary: exactly MAX_PRECISION is allowed.
+    solver = Solver("2 + 2", precision=MAX_PRECISION)
+    assert solver() == "4"
+
+
+def test_solver_accepts_zero_precision():
+    # Lower bound: 0 is allowed (used as the "all digits" sentinel).
+    solver = Solver("2 + 2", precision=0)
+    assert solver() == "4"
+
+
+def test_solver_rejects_negative_precision():
+    with pytest.raises(ValueError, match="precision must be in"):
+        Solver("x", precision=-1)
+
+
+def test_solver_rejects_precision_above_max():
+    with pytest.raises(ValueError, match="precision must be in"):
+        Solver("x", precision=MAX_PRECISION + 1)
+
+
+def test_max_precision_constant_value():
+    # If this ever changes, the error message and tests above need to follow.
+    assert MAX_PRECISION == 8192

--- a/tests/test_solver_precision_bounds.py
+++ b/tests/test_solver_precision_bounds.py
@@ -1,7 +1,5 @@
 """Regression: Solver enforces the documented precision bounds.
 
-See ai/improvements_2026-05-09.md item #19.
-
 `MAX_PRECISION = 8192` is exported from the package but used to be
 purely decorative — the wrapper forwarded any precision value straight
 to the C++ extension. Now Solver.__init__ rejects values outside


### PR DESCRIPTION
**Problem.** `MAX_PRECISION = 8192` is exported from `formula` but used to be purely decorative — `Solver.__init__` forwarded any value straight to the C++ extension. A typo like `precision=10000` quietly worked or produced surprising output instead of failing cleanly.

**Fix.** `src/formula/formula.py` — `Solver.__init__` now validates `0 <= precision <= MAX_PRECISION` and raises `ValueError` with a clear message naming both the bound and the offending value. The previously-pylint-disabled "useless super delegation" override now does meaningful work (so PR #20 / the cleanup batch will keep it instead of deleting it).

**Test.** New file `tests/test_solver_precision_bounds.py` covers: precision == MAX_PRECISION accepted; precision == 0 accepted (existing "all digits" sentinel); negative precision rejected; MAX_PRECISION + 1 rejected; constant pinned to 8192. Full suite 321/321.