### PR TITLE
feat: Solver.__call__ accepts legacy 'format=' as deprecated alias

### DIFF
--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -1,6 +1,7 @@
 """Solver wrapper to simplify calculations with Formula."""
 
 import operator
+import warnings
 from collections.abc import Mapping
 from typing import Any, Dict, Iterable, List, Optional, Union
 
@@ -69,6 +70,7 @@ class Solver(Formula):
         derivative: Optional[Union[str, Iterable[str]]] = None,
         format_digits: Optional[int] = None,
         format_flags=FmtFlags.default,
+        format=None,
     ) -> Union[List[str], str]:
         """Calculate the value of the parsed formula string.
 
@@ -91,10 +93,22 @@ class Solver(Formula):
             format_flags: Flags to format the return value.
                 If omitted output is generated in fixed-point notation and
                 decimal base.
+            format: Deprecated alias for ``format_flags``, kept for parity
+                with ``Formula.get``'s keyword name. Will be removed in a
+                future release; prefer ``format_flags``.
         Returns:
             Calculated value: string or the list of strings if the
                 'derivative' parameter is passed.
         """
+
+        if format is not None:
+            warnings.warn(
+                "Solver.__call__ 'format' keyword is deprecated; "
+                "use 'format_flags' instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            format_flags = format
 
         if format_digits is None:
             format_digits = self.precision

--- a/tests/test_solver_format_alias.py
+++ b/tests/test_solver_format_alias.py
@@ -1,0 +1,45 @@
+"""Regression: Solver accepts the legacy `format=` kwarg with a deprecation
+warning, while `format_flags=` is the preferred spelling going forward.
+
+See ai/improvements_2026-05-09.md item #25.
+
+Background: `Formula.get` (the C++ binding) uses the keyword `format=`,
+whereas the Python `Solver.__call__` wrapper introduced `format_flags=`.
+Users moving between the two APIs got keyword-argument errors. The
+wrapper now accepts both, emitting a DeprecationWarning for `format=`.
+"""
+
+import warnings
+
+import pytest
+
+from formula import FmtFlags, Solver
+
+
+def test_format_flags_preferred_no_warning():
+    solver = Solver("2*asin(x)", precision=24)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning becomes an exception
+        result = solver({"x": "1"}, format_flags=FmtFlags.fixed)
+    assert result.startswith("3.14")
+
+
+def test_format_legacy_kwarg_emits_deprecation_warning():
+    solver = Solver("2*asin(x)", precision=24)
+    with pytest.warns(DeprecationWarning, match="format_flags"):
+        result = solver({"x": "1"}, format=FmtFlags.fixed)
+    assert result.startswith("3.14")
+
+
+def test_format_and_format_flags_format_wins_and_warns():
+    # Both supplied: the legacy alias wins (to preserve old caller intent)
+    # and the deprecation warning still fires so the caller fixes it.
+    solver = Solver("2*asin(x)", precision=24)
+    with pytest.warns(DeprecationWarning):
+        result = solver(
+            {"x": "1"},
+            format_flags=FmtFlags.scientific,
+            format=FmtFlags.fixed,
+        )
+    # `format=FmtFlags.fixed` should override -> output begins "3.14..." not "3.14...e+00"
+    assert "e" not in result


### PR DESCRIPTION
Closes item #25 from `ai/improvements_2026-05-09.md`.

**Problem.** `Formula.get` (the C++ binding) takes the keyword `format=`; `Solver.__call__` took `format_flags=`. Users moving between the two APIs got keyword-argument errors and had to remember which spelling belonged to which class. The same test file uses both forms side-by-side (`tests/test_simple.py:103, 122, 128, 191` vs `Solver(...)(format_flags=...)`).

**Fix.** `src/formula/formula.py` — add `format=None` as an explicit kwarg on `Solver.__call__`. When supplied, emit a `DeprecationWarning` naming the replacement and override `format_flags`. New callers use `format_flags`; existing code keeps working.

Changing the C++ binding's keyword is out of scope here (a pybind11 signature change with broader downstream impact).

**Test.** New file `tests/test_solver_format_alias.py` covers:
- `format_flags=` works silently
- `format=` emits `DeprecationWarning` and still produces correct output
- both supplied: `format=` wins (legacy intent) and the warning still fires

Full suite 319/319.