### PR TITLE
chore: doc/style cleanup batch

### DIFF
--- a/boost_headers/update_command.py
+++ b/boost_headers/update_command.py
@@ -9,110 +9,118 @@ import shutil
 import urllib.request
 import zipfile
 
-parser = argparse.ArgumentParser(description="Download and update Boost headers.")
-parser.add_argument("--version", required=True, help="version of the Boost e.g. 1.79.0")
-args = parser.parse_args()
-version: str = args.version
-version_list = version.split(".")
-if len(version_list) != 3 or any(not el.isdigit() for el in version_list):
-    raise Exception("Wrong version, the pattern is D.DD.D, e.g. 1.78.0")
 
-script_dir = Path(__file__).parent
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Download and update Boost headers.")
+    parser.add_argument(
+        "--version", required=True, help="version of the Boost e.g. 1.79.0"
+    )
+    args = parser.parse_args()
+    version: str = args.version
+    version_list = version.split(".")
+    if len(version_list) != 3 or any(not el.isdigit() for el in version_list):
+        raise ValueError("Wrong version, the pattern is D.DD.D, e.g. 1.78.0")
 
-file_name = "_".join(("boost", *version_list))
-file_name_ext = file_name + ".zip"
-print("*" * 20)
-print("Output:", file_name_ext)
+    script_dir = Path(__file__).parent
 
-print("Download...")
+    file_name = "_".join(("boost", *version_list))
+    file_name_ext = file_name + ".zip"
+    print("*" * 20)
+    print("Output:", file_name_ext)
 
-url = f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{file_name_ext}"
-chunk_size = 65536
-with urllib.request.urlopen(url) as response, open(
-    script_dir / file_name_ext, "wb"
-) as out_file:
-    while data := response.read(chunk_size):
-        out_file.write(data)
+    print("Download...")
 
-print("Unzip...")
+    url = f"https://boostorg.jfrog.io/artifactory/main/release/{version}/source/{file_name_ext}"
+    chunk_size = 65536
+    with urllib.request.urlopen(url) as response, open(
+        script_dir / file_name_ext, "wb"
+    ) as out_file:
+        while data := response.read(chunk_size):
+            out_file.write(data)
 
-with zipfile.ZipFile(script_dir / file_name_ext, "r") as zip_ref:
-    zip_ref.extractall(script_dir)
+    print("Unzip...")
 
-print("Delete all except the 'boost' catalog with headers...")
-boost_entry: os.DirEntry | None = None
-for el in os.scandir(script_dir / file_name):
-    if el.name != "boost":
-        if el.is_dir():
-            shutil.rmtree(el)
-        else:
-            os.remove(el)
-    else:
-        boost_entry = el
+    with zipfile.ZipFile(script_dir / file_name_ext, "r") as zip_ref:
+        zip_ref.extractall(script_dir)
 
-if boost_entry is None:
-    raise Exception("Boost catalog does not exist!")
-
-print("Delete unused boost libs...")
-allowed_libs = {
-    "algorithm",
-    "assert",
-    "bind",
-    "concept",
-    "config",
-    "container_hash",
-    "container",
-    "core",
-    "detail",
-    "exception",
-    "format",
-    "function",
-    "functional",
-    "hana",
-    "integer",
-    "iterator",
-    "lambda",
-    "lexical_cast",
-    "math",
-    "move",
-    "mpl",
-    "multiprecision",
-    "numeric",
-    "optional",
-    "predef",
-    "preprocessor",
-    "range",
-    "smart_ptr",
-    "tuple",
-    "type_index",
-    "type_traits",
-    "typeof",
-    "utility",
-    "variant",
-    "winapi",
-}
-counter_del = counter_ok = 0
-for el in os.scandir(boost_entry):
-    if el.is_dir():
-        if el.name not in allowed_libs:
-            try:
+    print("Delete all except the 'boost' catalog with headers...")
+    boost_entry: os.DirEntry | None = None
+    for el in os.scandir(script_dir / file_name):
+        if el.name != "boost":
+            if el.is_dir():
                 shutil.rmtree(el)
-                counter_del += 1
-            except PermissionError:
-                print(el.path, "cannot be removed!")
+            else:
+                os.remove(el)
         else:
-            counter_ok += 1
-            allowed_libs.discard(el.name)
+            boost_entry = el
 
-if allowed_libs:
-    raise Exception("There are no such catalogues:", allowed_libs)
-print(f">>> Removed: {counter_del}, left unremoved: {counter_ok}")
+    if boost_entry is None:
+        raise RuntimeError("Boost catalog does not exist!")
 
-print("Move new boost_headers files...")
-shutil.rmtree(script_dir / "boost")
-Path(boost_entry).rename(script_dir / "boost")
+    print("Delete unused boost libs...")
+    allowed_libs = {
+        "algorithm",
+        "assert",
+        "bind",
+        "concept",
+        "config",
+        "container_hash",
+        "container",
+        "core",
+        "detail",
+        "exception",
+        "format",
+        "function",
+        "functional",
+        "hana",
+        "integer",
+        "iterator",
+        "lambda",
+        "lexical_cast",
+        "math",
+        "move",
+        "mpl",
+        "multiprecision",
+        "numeric",
+        "optional",
+        "predef",
+        "preprocessor",
+        "range",
+        "smart_ptr",
+        "tuple",
+        "type_index",
+        "type_traits",
+        "typeof",
+        "utility",
+        "variant",
+        "winapi",
+    }
+    counter_del = counter_ok = 0
+    for el in os.scandir(boost_entry):
+        if el.is_dir():
+            if el.name not in allowed_libs:
+                try:
+                    shutil.rmtree(el)
+                    counter_del += 1
+                except PermissionError:
+                    print(el.path, "cannot be removed!")
+            else:
+                counter_ok += 1
+                allowed_libs.discard(el.name)
 
-print("Clean up...")
-shutil.rmtree(script_dir / file_name)
-os.remove(script_dir / file_name_ext)
-print("*" * 20)
+    if allowed_libs:
+        raise RuntimeError(f"There are no such catalogues: {allowed_libs!r}")
+    print(f">>> Removed: {counter_del}, left unremoved: {counter_ok}")
+
+    print("Move new boost_headers files...")
+    shutil.rmtree(script_dir / "boost")
+    Path(boost_entry).rename(script_dir / "boost")
+
+    print("Clean up...")
+    shutil.rmtree(script_dir / file_name)
+    os.remove(script_dir / file_name_ext)
+    print("*" * 20)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/formula/__init__.py
+++ b/src/formula/__init__.py
@@ -7,3 +7,5 @@ from ._formula import FmtFlags, Formula
 from .formula import Solver, Number
 
 MAX_PRECISION = 8192
+
+__all__ = ["FmtFlags", "Formula", "Solver", "Number", "MAX_PRECISION"]


### PR DESCRIPTION
Combines three small cleanup items into one PR per the per-PR plan. None changes behaviour for normal callers.

- **`src/formula/__init__.py`**: add `__all__ = ["FmtFlags", "Formula", "Solver", "Number", "MAX_PRECISION"]`. Pins the public API surface for `from formula import *` so accidental imports from submodules don't escape into the package namespace. (Doc item **#18**.)

- **`boost_headers/update_command.py`**: wrap the top-level script body in `def main()` and gate the call with `if __name__ == "__main__":`. Lets IDEs, test discovery, and any future zip-slip-guard tests import the module without triggering the argparse + download + rmtree flow. (Doc item **#22**.)

- **`boost_headers/update_command.py`**: replace bare `Exception` raises with specific types — `ValueError` for bad input, `RuntimeError` for unexpected runtime state — so callers can catch by intent and pylint's `broad-exception-raised` stops firing. (Doc item **#23**.)

**Item #20 (Solver.__init__ useless-super-delegation) is intentionally deferred from this batch.** PR `fix/19-enforce-max-precision` (#31) adds validation to that method, making it non-trivial; removing the override here would conflict with #19. Once #19 lands the pylint suppression can be dropped in a follow-up without further change.

Full pytest suite 316/316. AST checks confirm: `main` is defined and there are no surviving top-level Call expressions; no `raise Exception(` remains; `formula.__all__` matches the expected list; the updated module is now importable without side effects.