### PR TITLE
docs: add AI engineering lessons from PR #18

### DIFF
--- a/ai/lessons/lessons_2026-05-08.md
+++ b/ai/lessons/lessons_2026-05-08.md
@@ -1,0 +1,358 @@
+# Lessons learned: building & shipping a pybind11 / C++ Python package
+
+Compiled while modernizing the formula build pipeline. Each tip is
+written so a future maintainer (or another project) can apply it
+without rediscovering the trap.
+
+---
+
+## Source layout
+
+### Flat layout has a built-in foot-gun: source-tree shadowing
+
+A repo with this structure:
+
+```
+repo/
+├── formula/                ← Python package
+│   └── __init__.py         ← imports from ._formula (the C extension)
+└── src/                    ← C++ extension sources
+```
+
+…breaks under any non-editable install. When `pytest` runs from the
+repo root, `sys.path[0] = ''` makes Python find the source `./formula/`
+directory **before** `site-packages`. That source directory has no
+compiled `_formula.so` until something has built it in-place. Result:
+
+```
+ModuleNotFoundError: No module named 'formula._formula'
+```
+
+This affects every OS, every Python version, and is invisible if you
+have a leftover `.so` in your local source tree from a previous
+editable install.
+
+**Fixes (ranked):**
+
+1. **src-layout**: move the package to `src/formula/` so the repo root
+   no longer contains a `formula/` directory at all. Add
+   `package_dir={"": "src"}` and `find_packages(where="src")` to
+   `setup.py`. Structurally impossible for shadowing to occur.
+2. **Editable install** (`pip install -e .`): with PEP 660 + setuptools
+   ≥ 64, the compiled `.so` lands in the source tree, so the source-tree
+   package is complete. Works around the symptom but not the cause.
+3. **`pytest --import-mode=importlib`**: pytest no longer prepends
+   rootdir to `sys.path`; the installed wheel is resolved from
+   `site-packages` instead. Edge-case workaround.
+
+### When verifying CI install changes, scrub stale build artifacts
+
+Before claiming "tests pass locally," remove leftover compiled
+extensions from the source tree:
+
+```bash
+rm -f <package>/_*.so <package>/*.pyd
+rm -rf <package>/__pycache__ build *.egg-info
+```
+
+Otherwise a previous editable install masks bugs that fresh CI
+checkouts will hit. (This caused a regression where I claimed CI was
+green; the user's first push immediately failed because the leftover
+`.so` had been silently saving me.)
+
+### Tests in sdist: yes; tests in wheel: no
+
+Standard for scientific Python:
+
+- **Sdist** includes tests so downstream packagers (Conda-forge,
+  distros, HPC sysadmins) can verify their build before shipping.
+  Cost: ~10% of typical sdist size.
+- **Wheel** excludes tests so users don't get a `tests` namespace in
+  their `site-packages`. Achieved automatically by
+  `find_packages(where="src")` when tests live at the repo root, not
+  under `src/`.
+
+---
+
+## Build configuration
+
+### `pybind11` is a build-only dependency, not runtime
+
+`Pybind11Extension` bakes the headers into the compiled `.so` at build
+time. Listing `pybind11` in `install_requires` would force users to
+install ~5 MB of headers they'd never use. Pin it in
+`pyproject.toml` `[build-system].requires` instead.
+
+### `MACOSX_DEPLOYMENT_TARGET` is critical for portable wheels
+
+If you don't set it, the resulting `.so` is tagged with the **build
+machine's** macOS version, and `pip install` on older Macs refuses to
+install. Common gotcha when building on `macos-latest`. Set:
+
+```bash
+export MACOSX_DEPLOYMENT_TARGET=10.15  # Intel
+# arm64 builds bump to 11.0+ automatically
+```
+
+…in CI env or in `setup.py` via `os.environ.setdefault(...)`.
+
+### Setuptools 70+ split linker config: `LDSHARED` is no longer enough for C++ extensions
+
+Setuptools introduced a separate `linker_so_cxx` for C++ extensions,
+populated from a new sysconfig variable: `LDCXXSHARED`. PyPy's
+sysconfig does not define `LDCXXSHARED`. Result for any extension
+declaring `language="c++"`:
+
+```
+TypeError: 'NoneType' object is not subscriptable
+  at unix.py:290 in link()
+```
+
+If you're setting `LDSHARED` for PyPy, set `LDCXXSHARED` too.
+Falls back to `LDSHARED` only on some setuptools versions; relying
+on it is fragile.
+
+### Don't touch `sysconfig._CONFIG_VARS` from `setup.py`
+
+A previous workaround mutated `sysconfig._CONFIG_VARS` to inject
+`LDSHARED` for PyPy/Linux. This is private API; it broke silently
+on PyPy/CPython upgrades. Set environment variables in CI workflow
+config instead — it's the supported, documented mechanism.
+
+---
+
+## GitHub Actions traps
+
+### `macos-latest` is now arm64
+
+Since mid-2024, `macos-latest` resolves to Apple Silicon runners. Any
+matrix that pins `architecture: x64` on `macos-latest` will silently
+fail (or get skipped). If you need x86_64 macOS:
+
+- Use `macos-13` explicitly for x86_64.
+- Use `macos-14` explicitly for arm64.
+- Drop `architecture: x64` for macOS rows entirely — `setup-python`
+  picks the right arch from the runner.
+
+### PyPy doesn't ship arm64 macOS builds
+
+`actions/setup-python@v5` will fail with "no matching distribution
+found" on `macos-14` + `pypy-3.9`/`pypy-3.10`. Exclude these matrix
+combinations explicitly so they don't add red noise.
+
+### Empty-string env vars in ternary expressions can break CPython
+
+```yaml
+env:
+  LDSHARED: ${{ startsWith(matrix.python, 'pypy') && 'g++ -shared' || '' }}
+```
+
+GitHub Actions sets `LDSHARED=""` for non-PyPy rows. Distutils'
+`customize_compiler` checks `'LDSHARED' in os.environ` (membership,
+not truthy), so an empty string overrides sysconfig's correct
+value with nothing → linker = empty → crash.
+
+**Use a conditional step exporting via `$GITHUB_ENV` instead:**
+
+```yaml
+- name: Configure PyPy linker
+  if: startsWith(matrix.python, 'pypy')
+  run: |
+    echo "LDSHARED=g++ -shared" >> "$GITHUB_ENV"
+    echo "LDCXXSHARED=g++ -shared" >> "$GITHUB_ENV"
+```
+
+Sets the var only when needed; leaves CPython's sysconfig untouched.
+
+### `cancel-in-progress: false` for release workflows
+
+The default `cancel-in-progress: true` is correct for PR CI but
+**dangerous** for releases: a re-run can cancel an in-flight upload
+mid-stream, leaving PyPI in a half-published state. Set explicitly
+on the publish workflow:
+
+```yaml
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+```
+
+### `python setup.py build_ext --inplace` is deprecated
+
+Setuptools ≥ 58 prints warnings; future versions will remove it. Use
+`pip install -e .` (PEP 660 editable) for the same effect through the
+supported path.
+
+### `python setup.py` is being phased out for *all* commands
+
+Including `bdist_wheel`, `sdist`, `develop`. Use `python -m build`,
+`python -m pip install -e`, etc. The PEP 517/660 toolchain is the
+future.
+
+---
+
+## Workflow secrets & permissions
+
+### `GITHUB_TOKEN` is auto-provisioned, not user-added
+
+Every workflow run gets a fresh `GITHUB_TOKEN` automatically. Do not
+add it as a repo secret. Available as `${{ secrets.GITHUB_TOKEN }}`
+or `${{ github.token }}` (same value).
+
+What you control is its **permissions**:
+
+- Repo `Settings → Actions → General → Workflow permissions`.
+- Workflow-level or job-level `permissions:` key.
+
+User-defined secrets (e.g. `PYPI_PASSWORD`) are different beasts.
+Those you do create manually in `Settings → Secrets and variables →
+Actions`.
+
+### Releases created with `GITHUB_TOKEN` don't re-trigger workflows
+
+This is intentional GitHub design to prevent infinite loops. So a
+workflow can safely call `gh release create` without worrying about
+the resulting `release: published` event re-firing the workflow. Use a
+PAT only if you specifically want the loop (rare).
+
+### `github-actions[bot]` is the identity, not a user
+
+When `GITHUB_TOKEN` performs an action, it shows up as
+`github-actions[bot]`. To let it bypass branch protection, search for
+the literal string `github-actions[bot]` (with the brackets) in the
+"bypass actors" field of your branch protection rule.
+
+---
+
+## Releasing
+
+### Automate version bump and release in one workflow
+
+Manual two-step releases (bump-and-tag locally, then create release
+on GitHub) drift apart. Single canonical workflow path: trigger via
+`workflow_dispatch` with a `version_bump` input, then bump → build →
+upload to PyPI → commit bump → tag → create GitHub release. Eliminates
+the "PyPI is ahead of git" drift.
+
+### Drop the `release: published` trigger if you have automated releases
+
+If `workflow_dispatch` is the canonical trigger, the manual
+`release: published` path is redundant and risky (a manual release
+without a version bump would re-upload to PyPI; only `--skip-existing`
+saves you).
+
+### `dry_run` mode should produce a draft, not nothing
+
+A useful dry-run lets you preview what would happen. Implementation:
+run the full release job but skip the commit/tag push, and pass
+`--draft --target ${{ github.sha }}` to `gh release create`. The
+target flag is required when no real tag was pushed.
+
+### `twine upload --skip-existing` is your friend
+
+Idempotent retries: re-running the workflow after a transient PyPI
+failure won't error if the version is already up. Pair with
+`--non-interactive` for CI.
+
+### Use `gh release create --generate-notes`
+
+Pulls in titles of merged PRs since the previous tag. Zero
+maintenance, looks great. Requires the previous tag to exist for the
+delta computation.
+
+---
+
+## cibuildwheel
+
+### Configure once in `pyproject.toml`, not per-OS in workflow
+
+`[tool.cibuildwheel]` and `[tool.cibuildwheel.linux/macos/windows]`
+sections live in `pyproject.toml`. The workflow then becomes a
+one-line `uses: pypa/cibuildwheel@v2`. Settings travel with the
+project, not the CI definition — easier to keep in sync across
+multiple workflows.
+
+### `test-skip` patterns to know
+
+```toml
+test-skip = "*universal2:arm64 pp*"
+```
+
+- `*universal2:arm64`: skips the arm64 slice of universal2 binaries
+  on x86_64 runners (Rosetta limitation).
+- `pp*`: skips PyPy wheel tests if your test command is slow on PyPy.
+
+### `MACOSX_DEPLOYMENT_TARGET` via `[tool.cibuildwheel.macos.environment]`
+
+```toml
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64", "universal2"]
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
+```
+
+Cleaner than setting it in each workflow step.
+
+---
+
+## Pytest
+
+### `--import-mode=importlib` for non-trivial layouts
+
+In any project where the source dir might be on `sys.path` next to an
+installed copy of the same package, prefer `--import-mode=importlib`.
+It uses the standard import system without rootdir manipulation.
+Particularly important inside cibuildwheel test commands where the
+project source AND the just-installed wheel both exist.
+
+### `__init__.py` files in `tests/` are usually unnecessary
+
+Pytest works without them via rootdir-based collection. Adding them
+turns `tests` into a regular package and triggers different
+sys.path-manipulation behavior in the default `--import-mode=prepend`,
+which is one of the things that surfaces source-tree shadowing.
+
+### Test layout: `tests/` outside `src/` keeps tests out of the wheel
+
+With src-layout, putting tests at the repo root (not under `src/`)
+means `find_packages(where="src")` finds the package only and the
+wheel doesn't pick up tests. No `exclude=` list needed.
+
+---
+
+## Misc
+
+### `find_packages(exclude=["tests", "tests.*"])` is a band-aid
+
+If you find yourself excluding tests from `find_packages`, you've
+probably got a layout problem. Move tests outside the package
+discovery root (i.e. adopt src-layout) and the exclude becomes
+unnecessary.
+
+### Read with `encoding="utf-8"` always
+
+```python
+with open("README.md", encoding="utf-8") as fh: ...
+```
+
+On Windows, the default encoding is `cp1252`. A UTF-8 README with any
+non-ASCII char will crash the build. One-character fix; saves a Windows
+CI failure.
+
+### Conda recipes don't need changes when you change paths
+
+`meta.yaml` typically references the package by name (`import: formula`)
+and uses git for source. As long as `pip install .` works, the conda
+build will work too. Don't waste time editing it during a refactor.
+
+### `pip install --no-build-isolation` is for advanced users
+
+It makes pip use the current env's setuptools/wheel/etc. instead of
+creating a fresh build env. Faster but fragile — only use when you
+know the exact build deps are present in the active env. Default
+(isolated build) is safer for CI.
+
+### Check `git status` before any structural refactor
+
+Especially before `git mv` operations — uncommitted changes get
+included in the rename, which makes the diff confusing. Make the
+working tree clean first.

--- a/ai/lessons/lessons_2026-05-09.md
+++ b/ai/lessons/lessons_2026-05-09.md
@@ -1,0 +1,252 @@
+# Lessons learned — 2026-05-09
+
+New traps and findings from this session. Complements
+[lessons.md](lessons.md); items already covered there are not repeated.
+
+---
+
+## cibuildwheel — advanced patterns
+
+### `inherit.environment = "append"` is required when stacking overrides
+
+Without `inherit.environment = "append"`, an `[[tool.cibuildwheel.overrides]]`
+block **completely replaces** the parent environment dict for matching
+builds. This silently drops inherited vars — most critically
+`MACOSX_DEPLOYMENT_TARGET` set in `[tool.cibuildwheel.macos.environment]`:
+
+```toml
+[tool.cibuildwheel.macos]
+environment = { MACOSX_DEPLOYMENT_TARGET = "10.15" }
+
+[[tool.cibuildwheel.overrides]]
+select = "pp*-macosx_*"
+inherit.environment = "append"                   # ← required
+environment = { LDCXXSHARED = "clang++ -bundle -undefined dynamic_lookup" }
+```
+
+Without `"append"`, the wheel builds but the deployment target silently
+reverts to the runner's macOS version — producing wheels that pip refuses
+to install on older Macs.
+
+### Windows `win32` vs `win_amd64` naming: no underscore before `32`
+
+cibuildwheel build identifiers:
+- `cp39-win_amd64` — 64-bit Windows (has an underscore before `amd64`)
+- `cp39-win32` — 32-bit Windows (**no underscore** before `32`)
+
+Common mistake: `skip = "pp*-win_*"` skips `pp39-win_amd64` but **not**
+`pp39-win32`. The correct pattern to skip all PyPy Windows builds is
+`pp*-win*` (no underscore, wildcard catches both).
+
+**Always verify patterns with fnmatch before pushing:**
+
+```python
+import fnmatch
+for t in ['pp39-win_amd64', 'pp39-win32']:
+    print(t, fnmatch.fnmatch(t, 'pp*-win*'))   # both True
+    print(t, fnmatch.fnmatch(t, 'pp*-win_*'))  # win32 = False!
+```
+
+### `skip` vs `test-skip` are different operations
+
+| Option | Effect |
+|---|---|
+| `skip = "pattern"` | Don't build the wheel at all |
+| `test-skip = "pattern"` | Build the wheel but don't run `test-command` |
+
+Use `test-skip` for builds where the wheel is valid but you can't run
+tests (e.g. cross-compiled `universal2:arm64` slice on x86_64 runner,
+PyPy slow test runs). Use `skip` only when you don't want to ship the
+wheel.
+
+### musllinux + Boost-heavy templates = compiler OOM
+
+The `musllinux_1_1` image ships an old GCC that runs out of memory
+during C++ template instantiation of deeply nested Boost types
+(e.g. `boost::variant` of 18 `cpp_bin_float<N>` precisions ×
+`apply_visitor`). The exit code is 1 but the only output is warnings,
+because the OOM kill happens before an error line is emitted.
+
+Community-recommended fix: switch to clang for musllinux:
+
+```toml
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux_*"
+before-build = "apk update && apk add clang"
+environment = { CC = "clang", CXX = "clang++", CFLAGS = "-O1", CXXFLAGS = "-O1", MAKEFLAGS = "-j1" }
+```
+
+This is not guaranteed to work if the template expansion is large
+enough. The pragmatic fallback is to skip all musllinux:
+`skip = "*-musllinux_*"`. Alpine users can `pip install --no-binary`
+to build from sdist with their local toolchain.
+
+### `before-build` package manager depends on base image
+
+| Image type | Package manager | Example |
+|---|---|---|
+| `manylinux*` (CentOS/RHEL) | `yum install -y` | `yum install -y libpng-devel` |
+| `manylinux_2_28` (Debian) | `apt-get install -y` | `apt-get install -y libpng-dev` |
+| `musllinux*` (Alpine) | `apk add` | `apk update && apk add clang` |
+
+Mixing these causes silent failures; the wrong package manager is not
+on `PATH` and the step exits 127.
+
+### Verify the full build matrix locally before pushing
+
+```python
+import tomllib, fnmatch
+from pathlib import Path
+
+data = tomllib.loads(Path("pyproject.toml").read_text())
+build_pat = data["tool"]["cibuildwheel"]["build"].split()
+skip_pat  = data["tool"]["cibuildwheel"]["skip"].split()
+
+def included(target):
+    return (any(fnmatch.fnmatch(target, p) for p in build_pat) and
+            not any(fnmatch.fnmatch(target, p) for p in skip_pat))
+
+# Test a representative sample
+for t in ["cp312-manylinux_x86_64", "cp312-musllinux_x86_64",
+          "pp311-manylinux_x86_64", "pp311-win_amd64", "cp312-win32"]:
+    print(f"{t:<28} {'BUILD' if included(t) else 'skip'}")
+```
+
+Catches glob bugs (wrong separators, unintended matches) before they
+waste CI minutes.
+
+---
+
+## cibuildwheel — versioning
+
+### cibuildwheel 2.23.x is the last safe 2.x series
+
+`v2.23.x` (late 2024) is the final 2.x release. Key differences
+when you upgrade to 3.0+:
+
+| Change | Impact |
+|---|---|
+| PyPy no longer built by default | Must add `enable = ["pypy"]` (or `["pypy", "pypy-eol"]`) |
+| PyPy 3.10 moved to `pypy-eol` | Need `enable = ["pypy-eol"]` to keep building it |
+| Requires Python ≥ 3.11 **to run** cibuildwheel | Runner must have Python 3.11+ (GH Actions runners do) |
+
+Until you're ready to handle the 3.0 PyPy opt-in change, stay on
+`v2.23.x`.
+
+---
+
+## PyPy — version availability
+
+### Always verify a PyPy version exists before adding it to the matrix
+
+PyPy tracks CPython releases on a delay of 1–2 years:
+
+- Adding `pp312-*` to cibuildwheel `build` and `"pypy-3.12"` to your
+  test matrix when PyPy 3.12 hasn't shipped yet wastes CI cycles and
+  produces confusing "no distribution found" errors.
+- Check [pypy.org/download.html](https://pypy.org/download.html) or
+  the official release list before adding any new `pp` version.
+
+As of May 2026: PyPy latest is v7.3.21 targeting **Python 3.11**.
+PyPy 3.12 does not exist yet.
+
+### PyPy releases per platform (as of mid-2026)
+
+| Platform | Builds? |
+|---|---|
+| Linux x86_64 | ✅ manylinux wheel |
+| macOS x86_64 | ✅ (macos-13 runner) |
+| macOS arm64 | ❌ Not shipped upstream |
+| Windows x64 | ✅ (via setup-python) |
+| Windows x86 | ❌ Not shipped upstream |
+| Alpine / musllinux | Technically yes via sdist; binary wheels very problematic |
+
+---
+
+## Release workflow
+
+### Version bump artifact must be passed between jobs explicitly
+
+When a workflow bumps `__init__.py` in one job and other jobs need
+the bumped file, **it must be passed as a GitHub Actions artifact** —
+the bumped file only exists in one runner's filesystem:
+
+```yaml
+# bump job
+- uses: actions/upload-artifact@v4
+  with:
+    name: bumped-source
+    path: src/formula/__init__.py
+
+# build job
+- uses: actions/download-artifact@v4
+  with:
+    name: bumped-source
+    path: src/formula/       # ← must match the package directory
+```
+
+If you forget the trailing `/` or use the wrong path, the artifact
+lands in the wrong directory and `setup.py` reads the old version.
+
+### `--target ${{ github.sha }}` is required for draft releases without a tag
+
+`gh release create v{version} --draft` requires a tag **or** an
+explicit target commit. If you skip the tag-push step during a dry run,
+omitting `--target` causes `gh` to fail with "ref not found":
+
+```bash
+gh release create "v${NEW_VERSION}" \
+  --draft \
+  --target "$COMMIT_SHA" \
+  --generate-notes \
+  dist/*
+```
+
+Without `--target`, gh tries to resolve the tag `vX.Y.Z` which doesn't
+exist yet. With `--target SHA`, the draft is anchored to the workflow's
+commit and can be reviewed or deleted without side effects.
+
+### Commit the version bump to the branch only after PyPI upload succeeds
+
+Pattern:
+
+```
+bump_version → build_wheels + build_sdist → upload_pypi → create_release
+                                                                ↑
+                                         commit src/formula/__init__.py here
+```
+
+If the commit happens earlier and any subsequent step fails, the branch
+records a version that was never actually published — creating a
+"ghost" tag. By committing only in the final `create_release` job
+(conditioned on `upload_pypi.result == 'success'`), the branch and
+PyPI stay in sync even on partial failures.
+
+---
+
+## Misc
+
+### `*-musllinux_i686` is essentially dead — always safe to skip
+
+32-bit Alpine Linux has a user base measurable in single digits.
+Include it in your skip pattern unconditionally:
+`skip = "*-musllinux_i686 ..."`. Nobody will notice, and you'll avoid
+occasional 32-bit toolchain surprises.
+
+### GH Actions boolean inputs serialize as strings in shell
+
+A `workflow_dispatch` input declared `type: boolean` arrives in the
+runner shell as the **string** `"true"` or `"false"`, not a shell
+boolean. Compare accordingly:
+
+```bash
+# Wrong (always false in bash — string is non-empty, thus truthy)
+if [[ $DRY_RUN ]]; then ...
+
+# Correct
+if [[ "$DRY_RUN" == "true" ]]; then ...
+```
+
+In workflow `if:` expressions, GH Actions evaluates it natively as a
+boolean, so `if: inputs.dry_run` works there. The mismatch only bites
+in `run:` shell blocks.

--- a/ai/lessons/lessons_2026-05-19.md
+++ b/ai/lessons/lessons_2026-05-19.md
@@ -1,0 +1,164 @@
+# Lessons learned — 2026-05-19
+
+Findings from the `Number` complex-equality session. Complements
+[lessons.md](lessons.md) and [lessons_2026-05-09.md](lessons_2026-05-09.md).
+
+---
+
+## `is_complex_` flag is sticky and set at parse time
+
+In `csformula.cpp::prepare_expression`, `is_complex_` is set by a regex
+match on `\bi\b`. Once true:
+
+- `GetCalculatedStringVisitor` always appends `+i*(imag_part)` to the
+  output — even when `imag_part == 0`.
+- The whole evaluation switches to `cseval_complex<mp_complex<N>>`,
+  where every operation goes through complex arithmetic.
+
+Consequences:
+
+- `Solver("1+i*0")()` returns `"1.000…+i*(0.000…)"`, not `"1"`. String
+  comparison against `Solver("1")()` fails even though math is equal.
+- Adding `+i*0` to a real expression can introduce drift on the **real
+  part**, because the real component now travels through the complex
+  eval path (`sin(pi/4)^2+cos(pi/4)^2+i*0` ≠ exact `1`).
+
+This is a design constraint of the parser. Don't try to "fix" it by
+stripping `+i*(0)` post-hoc — solve it in the comparison layer instead.
+
+---
+
+## Pair-of-strings beats concatenated-string for equality
+
+A single formatted string `"real+i*(imag)"` is fragile to compare:
+syntactic forms of the same value have different shapes. Splitting into
+`(real_str, imag_str)` with consistent per-side formatting makes the
+pair byte-comparable.
+
+`Formula::get_pair` (C++) / `Solver.pair()` (Python) implement this:
+real-only results return `(value_str, zero_str)` where `zero_str` is
+formatted with the **same** digits/format as the imaginary side would
+be. So `Number("1").pair_fixed == Number("1+i*0").pair_fixed` is True.
+
+Used by `Number.__eq__` and `Number.__hash__`.
+
+---
+
+## `FmtFlags.fixed` is the only canonical format
+
+Default (`FmtFlags.default`) and scientific notation have multiple
+string representations of the same value (`"1"` vs `"1.0"`,
+`"1e0"` vs `"1.000e0"`). For any equality / hashing, format with
+`FmtFlags.fixed` — then `format_digits=precision` makes the string
+deterministic.
+
+`Number.fixed` and `Number.pair_fixed` both apply this.
+
+---
+
+## Complex `^` drifts via `exp(b·log(a))` — by library design
+
+boost.multiprecision has no integer-exponent specialization for
+`mp_complex<N>::pow`. Every complex `a^b` is computed as
+`exp(b·log(a))`, a transcendental chain. Drift at precision=24:
+
+| Expression  | Math | Computed                  |
+|-------------|------|---------------------------|
+| `i^4`       | `1`  | `1 + i·1e-24`             |
+| `(1+i)^64`  | `2^32` | real exact + `i·2.5e-13` |
+
+Workaround: replace `z^n` (small integer `n`) with `z*z*…*z`. Complex
+`*` is exact.
+
+Real `^` with integer exponent uses square-and-multiply — exact.
+
+---
+
+## `bool` is a subclass of `int` — reject explicitly
+
+`isinstance(True, int)` is `True`. Any numeric guard like
+`isinstance(x, (int, float))` silently accepts `True`/`False`. If
+bools are not valid input, reject them **before** the numeric check:
+
+```python
+if isinstance(expression, bool):
+    raise TypeError(...)
+if isinstance(expression, (str, int, float)):
+    ...
+```
+
+Order matters — `bool` check first.
+
+---
+
+## `NotImplemented` (not `False`) in dunder comparisons
+
+In `__eq__`, `__lt__`, etc., returning `False` for an unknown type
+short-circuits Python's reflected dispatch. Returning `NotImplemented`
+gives the other operand a chance to handle the comparison:
+
+```python
+def __eq__(self, other):
+    if not isinstance(other, (Number, str, int, float)):
+        return NotImplemented      # not False
+    ...
+```
+
+This matters for symmetry: `5 == Number("5")` calls `int.__eq__` first,
+which returns `NotImplemented`, then Python tries `Number.__eq__` —
+only because the first call returned `NotImplemented` and not `False`.
+
+---
+
+## Extract shared input-coercion **before** adding the second call site
+
+When `Solver.__call__` and the new `Solver.pair()` both needed the same
+"coerce `values` argument into `Dict[str, str]`" logic, the right move
+was to extract `_coerce_variables_to_values()` first, then write
+`pair()` against it. Copy-pasting the coercion into `pair()` would
+have produced two divergent versions on the next bugfix.
+
+Rule: if you find yourself about to duplicate boundary logic, extract
+it in a prep commit, then add the new call site.
+
+---
+
+## `xfail` documents known drift; don't delete the test
+
+`Number("i^4") == Number("1")` is `False` by design (drift). Three
+options were considered:
+
+1. **Delete the test** — loses the documentation value.
+2. **Add `xfail`** + a `_via_mul` variant using `*` — keeps the
+   limitation visible in the test file and exercises the workaround.
+3. **Rewrite to `*`** — hides that `^` is broken for complex.
+
+Chose (2). The `xfail` reason string (`"complex ^ drifts via
+exp(b·log(a))"`) carries the explanation right next to the assertion.
+
+---
+
+## Editable install is required during Python-side development
+
+`pip install .` copies Python sources into `site-packages` once.
+Subsequent edits to `src/formula/formula.py` are **not** picked up —
+imports still resolve to the cached copy. Use `pip install -e .[test]`
+so Python edits land immediately; only C++ changes need a rebuild
+(which also happens automatically with `pip install -e .` on next
+import via scikit-build, but a full reinstall is more reliable for
+header changes).
+
+---
+
+## Memory vs `ai/lessons/` split
+
+- **Auto-memory** (`~/.claude/.../memory/`) — personal, cross-session,
+  not committed. Use for "this user prefers X", "previous incident
+  Y", workflow hints.
+- **`ai/lessons/`** (in repo) — visible to teammates and future AI
+  agents reading the repo. Use for project-specific traps that
+  anyone touching the code should know.
+
+If a note answers "what surprised me about this codebase?" — it goes
+in `ai/lessons/`. If it answers "how does this user like to work?" —
+auto-memory.


### PR DESCRIPTION
Extracted from #18 to keep that PR focused on the `Number` API changes. Each file captures lessons learned during the AI-assisted rework — see commit message for the per-file summary.

Files added under `ai/lessons/`:

- **`lessons_2026-05-08.md`** — pybind11/C++ build-and-ship lessons from modernizing the formula build pipeline.
- **`lessons_2026-05-09.md`** — cibuildwheel advanced patterns and other traps from the same session.
- **`lessons_2026-05-19.md`** — findings from the `Number` complex-equality work (`is_complex_` flag stickiness, signed-zero leak through `Solver.pair`, etc.).

Docs-only change. No code touched. No tests touched. PR #18 has a corresponding force-push to remove these files from its scope.