### PR TITLE
chore: delete stale variable-name NOTE/TODO from Formula::get doxygen

### DIFF
--- a/src/cpp/csformula/csformula.hpp
+++ b/src/cpp/csformula/csformula.hpp
@@ -182,9 +182,6 @@ class Formula {
    * Get the calculated value of the formula in accordance with
    * the 'map_variable_values' dictionary contains values of
    * the variables.
-   * NOTE: Variables can be only letters of the Latin alphabet
-   * ('a','b',...,'z') and 'i' (by default) reserved for complex
-   * number. TODO: why so?
    */
   template <typename RealOrComplex>
   RealOrComplex get(const std::map<std::string, RealOrComplex>


### PR DESCRIPTION
Closes TODO `src/cpp/csformula/csformula.hpp:187` (`* number. TODO: why so?`).

## Problem

The doxygen block on `Formula::get` carried a NOTE claiming variables must be single Latin letters `a`..`z` and `i`, followed by `TODO: why so?` questioning the constraint.

The constraint is **fictional** — `tests/test_simple.py::test_getting_variables` already passes with multi-character names (`qwe`, `xx`, `s_s_s.`) and Cyrillic names (`йцу4`). The parser accepts them; the NOTE was wrong.

## Change

Delete the NOTE and the trailing TODO. The remaining sentence ("Get the calculated value of the formula in accordance with the 'map_variable_values' dictionary…") stands on its own.

Doc-only. No code or tests changed. Full suite 388/388, 3 xfailed unchanged.