### PR TITLE
chore: drop unused funcs1ArgD declarations; clear stale TODO on derivative maps

### DIFF
--- a/src/cpp/cseval/cseval.hpp
+++ b/src/cpp/cseval/cseval.hpp
@@ -307,13 +307,12 @@ the sqrt derivative");
   static const std::map<std::string, Real (*)(Real, Real)> functionsTwoArgs;
   static const std::map<std::string, Real (*)(Real)> functionsOneArg;
 
-  // dictionaries contain references to derivatives of basic functions and their
-  // names: TODO: delete me?
+  // dictionaries contain references to derivatives of basic functions and
+  // their names:
   static const std::map<std::string, Real (*)(Real, Real)>
       functionsTwoArgsDLeft;
   static const std::map<std::string, Real (*)(Real, Real)>
       functionsTwoArgsDRight;
-  static const std::map<std::string, Real (*)(Real)> funcs1ArgD;
 };
 
 #endif  // EVAL_MPF_H

--- a/src/cpp/cseval/cseval_complex.hpp
+++ b/src/cpp/cseval/cseval_complex.hpp
@@ -315,7 +315,6 @@ the sqrt derivative");
       functionsTwoArgsDLeft;
   static const std::map<std::string, Complex (*)(Complex, Complex)>
       functionsTwoArgsDRight;
-  static const std::map<std::string, Complex (*)(Complex)> funcs1ArgD;
 };
 
 #endif  // EVAL_COMPLEX_MPF_H


### PR DESCRIPTION
Closes TODO `src/cpp/cseval/cseval.hpp:311` (`// names: TODO: delete me?`).

## Audit

The comment questioned three static-member maps. Grep across the whole tree:

| Map | Status |
|---|---|
| `functionsTwoArgsDLeft`  | **USED** — default argument to `calculate_derivative(...)` in both `cseval.hpp` / `cseval_complex.hpp`; defined in the matching `.cpp` files. |
| `functionsTwoArgsDRight` | **USED** — same. |
| `funcs1ArgD`             | **UNUSED** — declared in both `cseval.hpp:314` and `cseval_complex.hpp:316`, never defined, never referenced anywhere else under `src/cpp/`. |

## Change

- Delete the two `funcs1ArgD` static-member declarations (one real, one complex).
- Drop `TODO: delete me?` from `cseval.hpp`'s comment now that the audit answered it.
- Keep `functionsTwoArgsDLeft` / `functionsTwoArgsDRight` — they're load-bearing.

No behavior change. Full suite **388/388** (3 xfailed unchanged).