### PR TITLE
fix: derive MAX_PRECISION from the engine, not wrapper bindings

### DIFF
--- a/src/cpp/main.cpp
+++ b/src/cpp/main.cpp
@@ -38,6 +38,9 @@ PYBIND11_MODULE(_formula, m) {
            :toctree: _generate
     )pbdoc";
 
+  // Engine precision ceiling, independent of which mp_real_<P> wrappers are bound.
+  m.attr("MAX_PRECISION") = static_cast<unsigned>(max_precision);
+
   py::class_<std::ios_base::fmtflags>(m, "FmtFlags")
       .def(py::self | py::self)
       .def(py::self & py::self)

--- a/src/formula/backend.py
+++ b/src/formula/backend.py
@@ -24,7 +24,6 @@ COMPLEX_TYPES = tuple(
     getattr(_formula, n) for n in dir(_formula) if n.startswith(_COMPLEX_PREFIX)
 )
 
-# Largest precision the C++ backend was built with (mirrors AllowedPrecisions).
-MAX_PRECISION = max(
-    int(n[len(_REAL_PREFIX):]) for n in dir(_formula) if n.startswith(_REAL_PREFIX)
-)
+# Engine precision ceiling (csconstants::max_precision), independent of
+# which mp_real_<P> wrappers are bound.
+MAX_PRECISION = _formula.MAX_PRECISION

--- a/tests/test_solver_precision_bounds.py
+++ b/tests/test_solver_precision_bounds.py
@@ -8,7 +8,7 @@ to the C++ extension. Now Solver.__init__ rejects values outside
 
 import pytest
 
-from formula import MAX_PRECISION, Solver
+from formula import MAX_PRECISION, Solver, _formula
 
 
 def test_solver_accepts_max_precision():
@@ -36,6 +36,12 @@ def test_solver_rejects_precision_above_max():
 def test_max_precision_constant_value():
     # Capped by M_PI_STR's 8198 digits: a higher rung would lie about pi.
     assert MAX_PRECISION == 8192
+
+
+def test_max_precision_comes_from_engine():
+    # Regression: derived from the engine constant, not from scanning the
+    # bound mp_real_<P> wrappers — a sparse ladder must not shrink the bound.
+    assert MAX_PRECISION == _formula.MAX_PRECISION
 
 
 def test_pi_has_full_precision_at_max():


### PR DESCRIPTION
## Problem

`backend.py` computed `MAX_PRECISION` by scanning the bound `mp_real_<P>` wrapper
classes, so a .pyd with a sparse wrapper ladder (e.g. only `mp_real_24`) shrank the
Solver bound to 24:

    >>> Solver("sqrt(2)", precision=100)()
    ValueError: precision must be in [0, 24] (got 100)

The Formula engine itself evaluates at any `AllowedPrecisions` value regardless of
wrapper coverage — the two concepts are independent.

## Fix

- `main.cpp`: expose `csconstants::max_precision` as `_formula.MAX_PRECISION`.
- `backend.py`: read it directly instead of scanning wrappers.
- One regression test in `test_solver_precision_bounds.py`: the constant comes from
  the engine attr, not from the wrapper scan.
