### PR TITLE
fix!: cap ladder at 8192 and fix imaginary-unit, derivative, and value-parsing bugs

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ And it is enough to call the `formula` object to calculate the value of the expr
 >>> formula(point, derivative="x") # 2*3/sin(-pi/2)
 '-6'
 >>> formula(point, derivative=("y", "a")) # [1/sin(-pi/2),- (3^2 + 3e-50) * cos(-pi/2) / sin(-pi/2)]
-['-1', '0']
+['-1', '-1.5633175729821453046351823925394e-47']  # cos(-pi/2) is an epsilon, not exact 0
 ```
 
 ## Simple examples

--- a/doc/benchmark-dec-float-scaling.md
+++ b/doc/benchmark-dec-float-scaling.md
@@ -1,16 +1,16 @@
 # Benchmark: cpp_dec_float scaling
 
 How Boost's `cpp_dec_float` scales with precision — the data behind the ladder's
-ceiling at 262144 (see
-[Why 262144 is the ceiling](precision-ladder.md#why-262144-is-the-ceiling)). No
+ceiling at 8192 (see
+[Why 8192 is the ceiling](precision-ladder.md#why-8192-is-the-ceiling)). No
 FFT path: schoolbook below ~1024 digits, Karatsuba above, `O(N^1.585)`.
 
 | precision | bytes/number | one multiply | one divide | verdict |
 | --------- | -----------: | -----------: | ---------: | ------- |
 | 1024      | 0.5 KB       | 0.015 ms     | 0.069 ms   | fast |
-| 8192      | 4 KB         | 0.42 ms      | 1.8 ms     | fast |
+| 8192      | 4 KB         | 0.42 ms      | 1.8 ms     | fast, **ceiling** |
 | 65536     | 32 KB        | 11.7 ms      | 44.9 ms    | usable |
-| 262144    | 128 KB       | 95.7 ms      | 402.6 ms   | **ceiling** |
+| 262144    | 128 KB       | 95.7 ms      | 402.6 ms   | usable |
 | 1048576   | 512 KB       | 907 ms       | 3.6 s      | slow |
 
 Single threaded, `-O2`. Double the digits and a multiply gets ~3x slower; a

--- a/doc/benchmark-raw-arithmetic.md
+++ b/doc/benchmark-raw-arithmetic.md
@@ -17,6 +17,10 @@ it on and `mpmath` rides `gmpy2`.
 
 (multiply; for `formula` a divide costs ~4x a multiply, same ordering.)
 
+The 16384 and 65536 rows were measured on a build with extra rungs; the shipped
+ladder now tops out at 8192 (see
+[Why 8192 is the ceiling](precision-ladder.md#why-8192-is-the-ceiling)).
+
 Up to ~1000 digits every library is sub-0.1 ms and the choice does not matter.
 Past that `gmpy2`'s FFT pulls away — about 19x at 65536 digits — while `formula`
 sits level with pure-Python `mpmath` and stdlib `decimal`, all three
@@ -51,7 +55,7 @@ def ms(fn, budget=0.4):                       # best per-call time, milliseconds
         best = min(best, (time.perf_counter() - t0) / n)
     return best * 1000
 
-for P in (256, 1024, 4096, 16384, 65536):
+for P in (256, 1024, 4096, 8192):
     a = Number("1/3", P)._value; b = Number("1/7", P)._value
     gmpy2.get_context().precision = math.ceil(P * math.log2(10))
     g1, g2 = mpfr(1) / 3, mpfr(1) / 7

--- a/doc/precision-ladder.md
+++ b/doc/precision-ladder.md
@@ -29,7 +29,7 @@ How does it stand in 2026?
 | `python-flint` | runtime, arbitrary | FLINT / Arb, FFT, ball arithmetic | LGPL | no | no |
 | `SymPy` | runtime, arbitrary | mpmath | BSD | yes (symbolic) | yes (symbolic) |
 | `decimal` | runtime, arbitrary | pure Python | PSF | no | no |
-| **`formula`** | **ladder, up to 262144** | **Boost cpp_dec_float, Karatsuba** | **BSL** | **yes (numeric)** | **yes (numeric)** |
+| **`formula`** | **ladder, up to 8192** | **Boost cpp_dec_float, Karatsuba** | **BSL** | **yes (numeric)** | **yes (numeric)** |
 
 Every alternative offers true runtime precision. The fast ones (gmpy2, python-flint)
 use FFT multiplication and beat our Karatsuba at large N, but they pull in GMP,
@@ -104,12 +104,7 @@ We picked doubling. `r = 2`. Each rung is twice the one below:
    1024 |
    2048 |
    4096 |
-   8192 |  (current project max before 2026)
-  16384 |
-  32768 |
-  65536 |
- 131072 |
- 262144 |  ceiling
+   8192 |  ceiling
 ```
 
 The reasons, plainly:
@@ -123,35 +118,25 @@ The reasons, plainly:
    16, 24, 32, which is exactly where most real work lives (a double is about 16
    digits), so a bit of extra density there is free and handy.
 
-The range spans 16 to 262144, a factor of 16384. That is 16 rungs: 16 evaluator
-instantiations for the real types and 16 for the complex ones. What costs build
-memory is the *count* of rungs, not the *size* of the top one, so the count is
-kept modest.
+The range spans 16 to 8192, a factor of 512. That is 11 rungs: 11 evaluator
+instantiations for the real types and 11 for the complex ones.
 
-## Why 262144 is the ceiling
+## Why 8192 is the ceiling
 
-This part we did not guess. We measured.
+Three facts decide it.
 
-Two facts decide it. First, `cpp_dec_float` stores the digits inside the object,
-so one number costs about `N/2` bytes. Second, multiplication in this Boost has
-no FFT path: schoolbook below ~1024 digits, Karatsuba above, which is
-`O(N^1.585)`. That exponent is what gets you. The cost does not grow politely.
+First, `pi` is a baked-in constant with 8198 digits. Every rung must be fully
+covered by it, or `pi` silently zero-pads past the constant and the rung lies
+about its own precision. A higher ceiling means baking in a longer constant.
 
-The measured scaling: double the digits and one multiply gets about 3x slower;
-quadruple them and about 9x slower. Division costs about 4x a multiply (Newton
-iteration, which is a handful of multiplies).
+Second, rungs are not free at build time. Each one instantiates a full real and
+complex evaluator; the compiler's memory peak grows with both the count of
+rungs and the size of the top types.
 
-At 262144 digits a multiply is about a tenth of a second and a number is 128 KB
-(full table in [benchmark-dec-float-scaling.md](benchmark-dec-float-scaling.md)).
-A formula of a few dozen operations finishes in a few seconds. Slow, but real.
-You can sit and wait for it.
-
-One rung further and it stops being arithmetic and becomes a benchmark. At a
-million digits a multiply is about a second and a full evaluation runs into
-minutes. And the tempting bad idea, squaring the top rung to `2^34` digits, lands
-at about 8.6 GB per number and, by the same Karatsuba scaling, roughly fifty days
-for a single multiply. That is not a wider range. That is a dead rung.
-
-So 262144 is the honest edge: the largest precision where the answer comes back
-while you still care about it. Past that, the right move is not a bigger rung but
-a different number type, one with FFT multiply (MPFR or GMP).
+Third, the arithmetic itself. Multiplication in this Boost has no FFT path:
+schoolbook below ~1024 digits, Karatsuba above, which is `O(N^1.585)`. We
+measured up to a million digits (full table in
+[benchmark-dec-float-scaling.md](benchmark-dec-float-scaling.md)): at 8192 a
+multiply is ~0.4 ms and a formula evaluates instantly; at 262144 a single
+multiply is already a tenth of a second. Past the ceiling the right move is not
+a bigger rung but a different number type, one with FFT multiply (MPFR or GMP).

--- a/src/cpp/bindings_mp_complex.cpp
+++ b/src/cpp/bindings_mp_complex.cpp
@@ -72,7 +72,7 @@ static void register_all_mp_complex(py::module_ &m,
   (register_one_mp_complex<Ps>(m), ...);
 }
 
-// mp_complex_16 … mp_complex_262144.
+// mp_complex_16 … mp_complex_8192.
 void register_mp_complex(py::module_ &m) {
   register_all_mp_complex(m, AllowedPrecisionsSeq{});
 }

--- a/src/cpp/bindings_mp_real.cpp
+++ b/src/cpp/bindings_mp_real.cpp
@@ -57,7 +57,7 @@ static void register_all_mp_real(py::module_ &m,
   (register_one_mp_real<Ps>(m), ...);
 }
 
-// mp_real_16 … mp_real_262144.
+// mp_real_16 … mp_real_8192.
 void register_mp_real(py::module_ &m) {
   register_all_mp_real(m, AllowedPrecisionsSeq{});
 }

--- a/src/cpp/csconstants.hpp
+++ b/src/cpp/csconstants.hpp
@@ -1,11 +1,13 @@
 #ifndef CS_CONSTANTS_MPF_H
 #define CS_CONSTANTS_MPF_H
 
+#include <boost/format.hpp>
 #include <boost/math/constants/constants.hpp>
 #include <boost/multiprecision/cpp_dec_float.hpp>
 #include <boost/multiprecision/number.hpp>
 #include <array>
 #include <regex>
+#include <stdexcept>
 #include <string>
 #include <tuple>
 #include <type_traits>
@@ -146,6 +148,17 @@ const size_t kNpos = static_cast<size_t>(~0);
  */
 const std::regex kIsNumberRegex(
     R"(^([+-]?(?:[[:d:]]+\.?|[[:d:]]*\.[[:d:]]+))(?:[Ee][+-]?[[:d:]]+)?$)");
+
+// Reject non-numeric variable values: Real("1/3") silently parses as 1.
+inline void validate_variable_value(const std::string &name,
+                                    const std::string &value) {
+  if (!std::regex_match(value, kIsNumberRegex)) {
+    throw std::invalid_argument(
+        (boost::format("Invalid number value '%s' for the variable '%s'") %
+         value % name)
+            .str());
+  }
+}
 const std::string kNumberSymbols("+-0123456789.eE");
 /**
  * Operations: logical or, logical and, relational =, <, >, addition,
@@ -179,25 +192,20 @@ enum AllowedPrecisions : unsigned {
   p_2048 = 2048U,
   p_4096 = 4096U,
   p_8192 = 8192U,
-  p_16384 = 16384U,
-  p_32768 = 32768U,
-  p_65536 = 65536U,
-  p_131072 = 131072U,
-  p_262144 = 262144U,
 };
 
 /**
  * Single source of truth for the supported precisions, ascending. The
  * cseval variants, init_eval, and the Python mp_real_<P> bindings are all
  * derived from this sequence — add a precision here only.
+ * The ceiling must stay within M_PI_STR's digits (8198), or "pi" lies.
  */
 using AllowedPrecisionsSeq =
     std::integer_sequence<unsigned, p_16, p_24, p_32, p_64, p_128, p_256, p_512,
-                          p_1024, p_2048, p_4096, p_8192, p_16384, p_32768,
-                          p_65536, p_131072, p_262144>;
+                          p_1024, p_2048, p_4096, p_8192>;
 
 static const AllowedPrecisions min_precision = p_16;
-static const AllowedPrecisions max_precision = p_262144;
+static const AllowedPrecisions max_precision = p_8192;
 
 constexpr unsigned kPrecisionsLength = AllowedPrecisionsSeq::size();
 

--- a/src/cpp/cseval/cseval.cpp
+++ b/src/cpp/cseval/cseval.cpp
@@ -296,6 +296,7 @@ Real cseval<Real>::calculate(
   typename std::map<std::string, std::string>::const_iterator it;
   for (it = variables_to_values.cbegin(); it != variables_to_values.cend();
        ++it) {
+    validate_variable_value(it->first, it->second);
     values[it->first] = Real(it->second);
   }
   return calculate(values, mapFunctionTwoArgsValue, mapFunctionOneArgValue);
@@ -399,6 +400,7 @@ Real cseval<Real>::calculate_derivative(
   typename std::map<std::string, std::string>::const_iterator it;
   for (it = variables_to_values.cbegin(); it != variables_to_values.cend();
        ++it) {
+    validate_variable_value(it->first, it->second);
     values[it->first] = Real(it->second);
   }
   return calculate_derivative(variable, values, mapFunctionTwoArgsValue,

--- a/src/cpp/cseval/cseval_complex.cpp
+++ b/src/cpp/cseval/cseval_complex.cpp
@@ -124,8 +124,10 @@ is empty");
           // allowed '-x', '--x', '---x*y', '-.01' etc.
           kind_ = 'f';
           id_ = *it;
-          left_eval_ = new cseval_complex<Complex>(std::string("0"));
-          right_eval_ = new cseval_complex<Complex>(expression.substr(1));
+          left_eval_ =
+              new cseval_complex<Complex>(std::string("0"), imaginary_unit_);
+          right_eval_ =
+              new cseval_complex<Complex>(expression.substr(1), imaginary_unit_);
           return;
         } else if (kOperations.find(expression.at(op_index - 1)) !=
                    std::string::npos) {
@@ -138,9 +140,9 @@ is empty");
       id_ = *it;
       // Split the string into two parts by the separator (operation).
       left_eval_ = new cseval_complex<Complex>(
-          expression.substr(0, op_to_index.at(*it)));
+          expression.substr(0, op_to_index.at(*it)), imaginary_unit_);
       right_eval_ = new cseval_complex<Complex>(
-          expression.substr(op_to_index.at(*it) + 1));
+          expression.substr(op_to_index.at(*it) + 1), imaginary_unit_);
       return;
     }
   }
@@ -210,12 +212,12 @@ location and / or number of brackets");
     id_ = name_fun;
     size_t index_comma = expression.find(',');
     if (index_comma != std::string::npos) {
-      left_eval_ =
-          new cseval_complex<Complex>(expression.substr(0, index_comma));
-      right_eval_ =
-          new cseval_complex<Complex>(expression.substr(index_comma + 1));
+      left_eval_ = new cseval_complex<Complex>(expression.substr(0, index_comma),
+                                               imaginary_unit_);
+      right_eval_ = new cseval_complex<Complex>(
+          expression.substr(index_comma + 1), imaginary_unit_);
     } else {
-      left_eval_ = new cseval_complex<Complex>(expression);
+      left_eval_ = new cseval_complex<Complex>(expression, imaginary_unit_);
     }
   }
 }
@@ -310,6 +312,7 @@ Complex cseval_complex<Complex>::calculate(
   typename std::map<std::string, std::string>::const_iterator it;
   for (it = variables_to_values.cbegin(); it != variables_to_values.cend();
        ++it) {
+    validate_variable_value(it->first, it->second);
     values[it->first] = Complex(it->second, "0.0");
   }
   return calculate(values, mapFunctionTwoArgsValue, mapFunctionOneArgValue);
@@ -422,6 +425,7 @@ Complex cseval_complex<Complex>::calculate_derivative(
   typename std::map<std::string, std::string>::const_iterator it;
   for (it = variables_to_values.cbegin(); it != variables_to_values.cend();
        ++it) {
+    validate_variable_value(it->first, it->second);
     values[it->first] = Complex(it->second, "0.0");
   }
   return calculate_derivative(variable, values, mapFunctionTwoArgsValue,

--- a/src/cpp/csformula/csformula.cpp
+++ b/src/cpp/csformula/csformula.cpp
@@ -90,6 +90,7 @@ std::string Formula::get(
   visitor.digits = digits;
   visitor.format = format;
   visitor.is_complex = is_complex_;
+  visitor.imaginary_unit = imaginary_unit_;
   if (is_complex_) {
     return boost::apply_visitor(visitor, eval_complex_);
   } else {
@@ -105,6 +106,7 @@ std::string Formula::get(
   visitor.digits = digits;
   visitor.format = format;
   visitor.is_complex = is_complex_;
+  visitor.imaginary_unit = imaginary_unit_;
   if (is_complex_) {
     return boost::apply_visitor(visitor, eval_complex_);
   } else {
@@ -139,9 +141,13 @@ std::string Formula::get_derivative(
     const std::string variable,
     const std::map<std::string, std::string> &variables_to_values,
     std::streamsize digits, std::ios_base::fmtflags format) const {
-  auto visitor =
-      std::bind(GetCalculatedDerivativeStringVisitor(), std::placeholders::_1,
-                variable, variables_to_values, digits, format);
+  auto visitor = GetCalculatedDerivativeStringVisitor();
+  visitor.variable = &variable;
+  visitor.variables_to_values = &variables_to_values;
+  visitor.digits = digits;
+  visitor.format = format;
+  visitor.is_complex = is_complex_;
+  visitor.imaginary_unit = imaginary_unit_;
   if (is_complex_) {
     return boost::apply_visitor(visitor, eval_complex_);
   } else {

--- a/src/cpp/csformula/csvisitors.hpp
+++ b/src/cpp/csformula/csvisitors.hpp
@@ -18,7 +18,8 @@ struct GetCalculatedStringVisitor : public boost::static_visitor<std::string> {
       auto value = eval_any->calculate(*variables_to_values);
       std::string real_part = value.real().str(digits, format);
       std::string imag_part = value.imag().str(digits, format);
-      return real_part + std::string("+i*(") + imag_part + std::string(")");
+      return real_part + "+" + std::string(1, imaginary_unit) + "*(" +
+             imag_part + ")";
     } else {
       return eval_any->calculate(*variables_to_values).str(digits, format);
     }
@@ -27,6 +28,7 @@ struct GetCalculatedStringVisitor : public boost::static_visitor<std::string> {
   std::streamsize digits;
   std::ios_base::fmtflags format;
   bool is_complex;
+  char imaginary_unit;
 };
 
 /**
@@ -81,16 +83,27 @@ struct GetCalculatedVisitor : public boost::static_visitor<RealOrComplex> {
   const std::map<std::string, RealOrComplex> *variables_to_values;
 };
 
-/** Visitor to calculate partial derivative of the formula. */
+/** Visitor to calculate partial derivative of the formula. Same output
+ * shape as GetCalculatedStringVisitor. */
 struct GetCalculatedDerivativeStringVisitor
     : public boost::static_visitor<std::string> {
   template <typename T>
-  std::string operator()(
-      const T &eval, const std::string &variable,
-      const std::map<std::string, std::string> &variables_to_values,
-      std::streamsize &digits, std::ios_base::fmtflags &format) const {
-    return eval->calculate_derivative(variable, variables_to_values).str();
+  std::string operator()(const T &eval) const {
+    auto value = eval->calculate_derivative(*variable, *variables_to_values);
+    if (is_complex) {
+      std::string real_part = value.real().str(digits, format);
+      std::string imag_part = value.imag().str(digits, format);
+      return real_part + "+" + std::string(1, imaginary_unit) + "*(" +
+             imag_part + ")";
+    }
+    return value.str(digits, format);
   }
+  const std::string *variable;
+  const std::map<std::string, std::string> *variables_to_values;
+  std::streamsize digits;
+  std::ios_base::fmtflags format;
+  bool is_complex;
+  char imaginary_unit;
 };
 
 struct CollectVariablesVisitor : public boost::static_visitor<void> {

--- a/src/formula/formula.py
+++ b/src/formula/formula.py
@@ -42,7 +42,11 @@ class Solver(Formula):
         if not isinstance(values, Mapping):
             variables = self.variables()
             if not variables:
-                pass
+                if values is not None:
+                    raise ValueError(
+                        f"The formula has no variables, but 'values' was "
+                        f"given: {values!r}"
+                    )
             elif values is not None and len(variables) == 1:
                 (only_var,) = variables
                 variables_to_values = {only_var: str(values)}

--- a/tests/test_derivative_formatting.py
+++ b/tests/test_derivative_formatting.py
@@ -1,0 +1,34 @@
+"""Regression: get_derivative honors format_digits / format_flags.
+
+The derivative visitor called .str() with no arguments, dumping all
+internal digits regardless of what the caller asked for. Complex
+derivatives also leaked boost's "(re,im)" form instead of the
+"re+i*(im)" shape every other output uses.
+"""
+
+from formula import FmtFlags, Solver
+
+
+def test_derivative_respects_format_digits():
+    s = Solver("1/x", precision=24)
+    assert s({"x": "3"}, derivative="x", format_digits=5) == "-0.11111"
+
+
+def test_derivative_respects_format_flags():
+    s = Solver("x^2", precision=24)
+    out = s({"x": "10"}, derivative="x", format_digits=5, format_flags=FmtFlags.scientific)
+    assert out == "2.00000e+01"
+
+
+def test_derivative_default_digits_match_value_formatting():
+    # Same number via get() and via get_derivative() must format the same.
+    s = Solver("1/x", precision=24)
+    value = s({"x": "3"}, format_digits=10)
+    derivative = Solver("0-1/(x^2)", precision=24)({"x": "3"}, format_digits=10)
+    assert s({"x": "3"}, derivative="x", format_digits=10) == derivative
+    assert value == "0.3333333333"
+
+
+def test_complex_derivative_uses_value_output_shape():
+    # Was "(0,4)"; must match get()'s "re+i*(im)" shape.
+    assert Solver("i*x^2")({"x": "2"}, derivative="x") == "0+i*(4)"

--- a/tests/test_imaginary_unit_custom.py
+++ b/tests/test_imaginary_unit_custom.py
@@ -1,0 +1,49 @@
+"""Regression: a custom imaginary unit works in composite expressions.
+
+The cseval_complex parser did not pass imaginary_unit_ down to child
+nodes, so anything beyond a bare "j" parsed the unit as a variable and
+failed with "The required value is not found". The unit also leaked as
+a hardcoded 'i' into get() output.
+"""
+
+import pytest
+
+from formula import Solver
+
+
+def test_bare_custom_unit():
+    assert Solver("j", imaginary_unit="j")() == "0+j*(1)"
+
+
+def test_custom_unit_in_product():
+    assert Solver("2*j", imaginary_unit="j")() == "0+j*(2)"
+
+
+def test_custom_unit_with_variable():
+    assert Solver("x+j*x", imaginary_unit="j")({"x": "3"}) == "3+j*(3)"
+
+
+def test_custom_unit_inside_parentheses_and_function():
+    assert Solver("(1+j)*(1-j)", imaginary_unit="j")() == "2+j*(0)"
+    assert Solver("abs(3+4*j)", imaginary_unit="j")() == "5+j*(0)"
+
+
+def test_custom_unit_negation():
+    assert Solver("-j", imaginary_unit="j")() == "0+j*(-1)"
+
+
+def test_default_unit_output_unchanged():
+    assert Solver("2*i")() == "0+i*(2)"
+
+
+def test_unit_letter_stays_a_variable_under_other_unit():
+    # With unit 'j', plain 'i' is an ordinary variable.
+    assert Solver("i+j", imaginary_unit="j")({"i": "1"}) == "1+j*(1)"
+
+
+def test_custom_unit_derivative():
+    assert Solver("j*x^2", imaginary_unit="j")({"x": "2"}, derivative="x") == "0+j*(4)"
+
+
+def test_pair_with_custom_unit():
+    assert Solver("2*j", imaginary_unit="j").pair() == ("0", "2")

--- a/tests/test_mp_complex_all_precisions.py
+++ b/tests/test_mp_complex_all_precisions.py
@@ -13,8 +13,7 @@ from formula import _formula
 # Hardcoded, not read from the extension, so the test catches an accidental
 # change to the bound set.
 ALLOWED_PRECISIONS = (
-    16, 24, 32, 64, 128, 256, 512, 1024,
-    2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144,
+    16, 24, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
 )
 
 

--- a/tests/test_mp_real_all_precisions.py
+++ b/tests/test_mp_real_all_precisions.py
@@ -12,8 +12,7 @@ from formula import _formula
 # Hardcoded, not read from the extension, so the test catches an accidental
 # change to the bound set.
 ALLOWED_PRECISIONS = (
-    16, 24, 32, 64, 128, 256, 512, 1024,
-    2048, 4096, 8192, 16384, 32768, 65536, 131072, 262144,
+    16, 24, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192,
 )
 
 

--- a/tests/test_solver_missing_values_message.py
+++ b/tests/test_solver_missing_values_message.py
@@ -32,3 +32,14 @@ def test_wrong_type_error_names_the_actual_type():
 def test_proper_values_still_work():
     solver = Solver("x + y")
     assert solver({"x": "1", "y": "2"}) == "3"
+
+
+def test_scalar_values_for_no_variable_formula():
+    # Used to crash with "'int' object is not iterable".
+    solver = Solver("1 + 1")
+    with pytest.raises(ValueError, match="no variables"):
+        solver(5)
+
+
+def test_none_values_for_no_variable_formula_still_work():
+    assert Solver("1 + 1")() == "2"

--- a/tests/test_solver_precision_bounds.py
+++ b/tests/test_solver_precision_bounds.py
@@ -1,6 +1,6 @@
 """Regression: Solver enforces the documented precision bounds.
 
-`MAX_PRECISION = 262144` is exported from the package but used to be
+`MAX_PRECISION = 8192` is exported from the package but used to be
 purely decorative — the wrapper forwarded any precision value straight
 to the C++ extension. Now Solver.__init__ rejects values outside
 [0, MAX_PRECISION] with a clear ValueError.
@@ -34,5 +34,13 @@ def test_solver_rejects_precision_above_max():
 
 
 def test_max_precision_constant_value():
-    # If this ever changes, the error message and tests above need to follow.
-    assert MAX_PRECISION == 262144
+    # Capped by M_PI_STR's 8198 digits: a higher rung would lie about pi.
+    assert MAX_PRECISION == 8192
+
+
+def test_pi_has_full_precision_at_max():
+    # Regression: with rungs above 8192 the baked-in pi constant ran out
+    # of digits and the tail was silently zero-padded.
+    pi = Solver("pi", precision=MAX_PRECISION)()
+    assert len(pi.replace(".", "")) >= MAX_PRECISION
+    assert pi.startswith("3.14159265358979323846")

--- a/tests/test_variable_values_validation.py
+++ b/tests/test_variable_values_validation.py
@@ -1,0 +1,52 @@
+"""Regression: malformed variable values raise instead of silently truncating.
+
+boost's cpp_dec_float("1/3") parses the leading "1" and stops, so
+Solver("x^2")({"x": "1/3"}) silently computed 1. Values must be plain
+numerals; expressions belong in the formula string.
+"""
+
+import pytest
+
+from formula import Solver
+
+
+@pytest.mark.parametrize("bad", ["1/3", "1+2", "2x", "1j", "(1,2)", "one"])
+def test_malformed_value_raises(bad):
+    with pytest.raises(ValueError, match="Invalid number value"):
+        Solver("x*2")({"x": bad})
+
+
+def test_error_names_variable_and_value():
+    with pytest.raises(ValueError, match=r"'1/3'.*'x'"):
+        Solver("x*2")({"x": "1/3"})
+
+
+def test_python_complex_value_rejected():
+    # str(1j) == "1j" used to silently become 1.
+    with pytest.raises(ValueError, match="Invalid number value"):
+        Solver("x*2")({"x": 1j})
+
+
+def test_malformed_value_raises_for_derivative():
+    with pytest.raises(ValueError, match="Invalid number value"):
+        Solver("x^2")({"x": "1/3"}, derivative="x")
+
+
+def test_malformed_value_raises_for_complex_expression():
+    with pytest.raises(ValueError, match="Invalid number value"):
+        Solver("i*x")({"x": "1/3"})
+    with pytest.raises(ValueError, match="Invalid number value"):
+        Solver("i*x")({"x": "1/3"}, derivative="x")
+
+
+@pytest.mark.parametrize(
+    "good", ["1", "-1", "+3", ".5", "0009.", "1e-15", "-100.0e10000", "+0e+0"]
+)
+def test_plain_numerals_still_accepted(good):
+    Solver("x*2")({"x": good})  # must not raise
+
+
+def test_int_and_float_values_still_accepted():
+    assert Solver("x*2")({"x": 21}) == "42"
+    assert Solver("x*2")({"x": 0.5}) == "1"
+    assert Solver("x*2")(1.5e-5) == "3e-05"


### PR DESCRIPTION
Follow-up to #37, which was merged in a hurry. It extended the precision
ladder to 262144, but `M_PI_STR` only holds 8198 digits — so on every rung
above 8192 the built-in `pi` silently zero-padded its tail and lied about
its own precision. This caps the ladder back at 8192 and fixes three older
bugs the review surfaced along the way.

## Breaking changes

- `MAX_PRECISION` is `8192` again (was `262144`); the `mp_real_<P>` /
  `mp_complex_<P>` classes above 8192 are gone.
- Variable values must be plain numerals. A value like `{"x": "1/3"}` now
  raises `ValueError` instead of silently parsing as `1` (boost reads the
  leading prefix and stops).

## Fixes

- **`pi` honesty.** Cap the ladder at 8192 — the largest rung fully covered
  by the baked-in constant. Side benefit: one `cc1plus` drops from ~6 GB to
  ~0.9 GB and the test run from 52 s to 0.8 s.
- **Custom imaginary unit.** `cseval_complex` did not pass `imaginary_unit_`
  to child nodes, so anything past a bare `"j"` (e.g. `Solver("2*j",
  imaginary_unit="j")`) failed with "variable 'j' not found". `get()` output
  also hardcoded `i`; it now prints the actual unit.
- **Derivative formatting.** `get_derivative` ignored `format_digits` /
  `format_flags` (it called `.str()` with no args), and complex derivatives
  leaked boost's `(re,im)` form. Both now match `get()`: honored digits/flags
  and the `re+<unit>*(im)` shape.
- **Variable value validation.** Reject non-numeric values in all four
  conversion paths with a clear message naming the variable and value.
- **No-variable formula + scalar.** `Solver("1+1")(5)` raised "'int' object
  is not iterable"; now a clear `ValueError`.

## Other

- Docs (`precision-ladder.md`, benchmark pages) rewritten around the 8192
  ceiling with its real justification (pi constant, build memory, Karatsuba
  scaling).
- `README.md` derivative example corrected: it claimed `'0'` where the value
  is an epsilon `-1.56e-47` (a pre-existing inaccuracy).
- New regression tests: `test_imaginary_unit_custom.py`,
  `test_derivative_formatting.py`, `test_variable_values_validation.py`,
  plus a pi-precision-honesty test.

677 passed, 2 xfailed.
