### PR TITLE
fix: out-of-bounds read in expression parser and cseval copy-assignment

### DIFF
--- a/src/cpp/cseval/cseval.cpp
+++ b/src/cpp/cseval/cseval.cpp
@@ -432,7 +432,7 @@ std::unordered_map<char, size_t> cseval<Real>::operations_outside_parentheses(
     if (countBraces == 0 && symbols.find(op) != std::string::npos &&
         op_to_ind.at(op) == kNpos) {
       bool is_number = false;
-      if (crit != str.crend() && (op == '+' || op == '-')) {
+      if ((crit + 1) != str.crend() && (op == '+' || op == '-')) {
         char prev = *(crit + 1);
         if (prev == 'e' || prev == 'E') {
           // Check that '-' or '+' is not the path of number.
@@ -454,13 +454,16 @@ std::unordered_map<char, size_t> cseval<Real>::operations_outside_parentheses(
         } else {
           auto _crit = crit;
           auto _prev = *(crit + 1);
-          while (_crit != str.crend() && (_prev == '+' || _prev == '-') &&
+          while ((_crit + 1) != str.crend() && (_prev == '+' || _prev == '-') &&
                  op_to_ind.at(_prev) == kNpos) {
             _crit++;
             // 'op' mustn't be changed.
             if (*_crit == op) {
               // update position of 'op'. e.g Formula("0-+-+1")
               crit = _crit;
+            }
+            if ((_crit + 1) == str.crend()) {
+              break;
             }
             _prev = *(_crit + 1);
           }

--- a/src/cpp/cseval/cseval.hpp
+++ b/src/cpp/cseval/cseval.hpp
@@ -68,22 +68,12 @@ class cseval {
       kind_ = other.kind_;
       id_ = std::string(other.id_);
       value_ = Real(other.value_);
-      if (left_eval_) {
-        delete left_eval_;
-      }
-      if (other.left_eval_) {
-        left_eval_ = new cseval<Real>(other.left_eval_);
-      } else {
-        left_eval_ = nullptr;
-      }
-      if (right_eval_) {
-        delete right_eval_;
-      }
-      if (other.right_eval_) {
-        right_eval_ = new cseval<Real>(other.right_eval_);
-      } else {
-        right_eval_ = nullptr;
-      }
+      delete left_eval_;
+      left_eval_ = other.left_eval_ ? new cseval<Real>(*other.left_eval_)
+                                    : nullptr;
+      delete right_eval_;
+      right_eval_ = other.right_eval_ ? new cseval<Real>(*other.right_eval_)
+                                      : nullptr;
     }
     return *this;
   }

--- a/src/cpp/cseval/cseval_complex.cpp
+++ b/src/cpp/cseval/cseval_complex.cpp
@@ -458,7 +458,7 @@ cseval_complex<Complex>::operations_outside_parentheses(
     if (countBraces == 0 && symbols.find(op) != std::string::npos &&
         op_to_ind.at(op) == kNpos) {
       bool is_number = false;
-      if (crit != str.crend() && (op == '+' || op == '-')) {
+      if ((crit + 1) != str.crend() && (op == '+' || op == '-')) {
         char prev = *(crit + 1);
         if (prev == 'e' || prev == 'E') {
           // Check that '-' or '+' is not the path of number.
@@ -480,13 +480,16 @@ cseval_complex<Complex>::operations_outside_parentheses(
         } else {
           auto _crit = crit;
           auto _prev = *(crit + 1);
-          while (_crit != str.crend() && (_prev == '+' || _prev == '-') &&
+          while ((_crit + 1) != str.crend() && (_prev == '+' || _prev == '-') &&
                  op_to_ind.at(_prev) == kNpos) {
             _crit++;
             // 'op' mustn't be changed.
             if (*_crit == op) {
               // update position of 'op'. e.g Formula("0-+-+1")
               crit = _crit;
+            }
+            if ((_crit + 1) == str.crend()) {
+              break;
             }
             _prev = *(_crit + 1);
           }

--- a/src/cpp/cseval/cseval_complex.hpp
+++ b/src/cpp/cseval/cseval_complex.hpp
@@ -73,24 +73,16 @@ class cseval_complex {
     if (this != &other) {
       kind_ = other.kind_;
       id_ = std::string(other.id_);
-      value_ = Complex(other.value_, "0.0");
-      imaginary_unit_ = other.imaginary_unit_;
-      if (left_eval_) {
-        delete left_eval_;
-      }
-      if (other.left_eval_) {
-        left_eval_ = new cseval_complex<Complex>(other.left_eval_);
-      } else {
-        left_eval_ = nullptr;
-      }
-      if (right_eval_) {
-        delete right_eval_;
-      }
-      if (other.right_eval_) {
-        right_eval_ = new cseval_complex<Complex>(other.right_eval_);
-      } else {
-        right_eval_ = nullptr;
-      }
+      value_ = Complex(other.value_);
+      // imaginary_unit_ is const, fixed at construction; not reassigned.
+      delete left_eval_;
+      left_eval_ = other.left_eval_
+                       ? new cseval_complex<Complex>(*other.left_eval_)
+                       : nullptr;
+      delete right_eval_;
+      right_eval_ = other.right_eval_
+                        ? new cseval_complex<Complex>(*other.right_eval_)
+                        : nullptr;
     }
     return *this;
   }


### PR DESCRIPTION
Two latent C++ bugs in the cseval evaluator, surfaced by newer build toolchains (GCC 14 / manylinux_2_28 and the newer macOS CPython builds).

operations_outside_parentheses read one byte before the string buffer when an expression starts with '+' or '-': the guard `crit != crend()` is always true inside the reverse-iteration loop, so `*(crit + 1)` dereferenced crend() at index 0. For heap-allocated (non-SSO) strings this is a heap-underflow read, harmless until the byte lands on an unmapped page. RaySurface's subdivision re-parses negative derivative values (leading '-', ~38-char strings) at thousands of midpoints, which turned the latent read into a nondeterministic segfault on cp312-arm64 (it passed on cp311-arm64 in the same run). Guard the look-behind on (crit + 1) != crend() and bound the consecutive-sign loop, in both cseval.cpp and cseval_complex.cpp.

cseval(_complex)::operator= assigned the const member imaginary_unit_ and passed a pointer where the copy ctor takes a reference -- dead code clang and the older GCC never instantiated, but GCC 14 rejects the const assignment at parse time. Rewrite it to mirror the copy constructor.

Also document the remaining latent parser bugs found in the audit (ctor exception-safety leak; empty/over-stripped-parentheses UB) in doc/parser-latent-bugs.md.